### PR TITLE
Fix multi-region deploy for Lambda layer and DynamoDB

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -76,7 +76,7 @@ def run():
             Role=lambda_role_arn,
             Handler="lambda_function.lambda_handler",
             Layers=[
-                f"arn:aws:lambda:us-east-1:{sts.get_caller_identity()['Account']}:layer:slack:1"
+                f"arn:aws:lambda:{region}:{sts.get_caller_identity()['Account']}:layer:slack:1"
             ],
             Code={"ZipFile": open(zipped, "rb").read()},
             Timeout=300,
@@ -123,7 +123,7 @@ def run():
         )
 
         # Create DynamoDB table if not existed
-        dynamodb_client = boto3.client('dynamodb')
+        dynamodb_client = boto3.client('dynamodb', region_name=region)
         try:
             response = dynamodb_client.create_table(
                 AttributeDefinitions=[


### PR DESCRIPTION
## Summary
- Fix Lambda layer ARN to use the deploy loop's region instead of hardcoded `us-east-1`, which caused `CreateFunction` to fail in all non-us-east-1 regions
- Fix DynamoDB client to pass `region_name=region`, so the GDPatrol table is created in every region instead of only the default region

## Test plan
- [x] Deployed successfully to all 17 regions on test account (`AWS_PROFILE=test`)
- [x] Deployed successfully to all 17 regions on prod account (`AWS_PROFILE=default`)
- [x] Verified no errors in Lambda logs across both accounts
- [x] Created missing DynamoDB tables in all regions on prod (previously only existed in us-east-1)
- [x] Published slack Lambda layer to all regions on both accounts
- [x] Linted with pycodestyle — no new warnings introduced