### PR TITLE
Add CI: GitHub Actions, ruff, pytest, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: "3.14"
-      - run: uv pip install --system pytest moto boto3 requests
-      - run: pytest tests/ -v
+      - run: uv python install 3.14
+      - run: uv venv --python 3.14
+      - run: uv pip install pytest moto boto3 requests
+      - run: uv run pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: check
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.14"
+      - run: uv pip install --system pytest moto boto3 requests
+      - run: pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: testing
+      AWS_SECRET_ACCESS_KEY: testing
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/GDPatrol/config.json
+++ b/GDPatrol/config.json
@@ -343,7 +343,7 @@
         "actions": [
           "blacklist_ip"
         ],
-        "reliability": 5
+        "reliability": 7
       },
       {
         "type": "CredentialAccess:RDS/AnomalousBehavior.FailedLogin",
@@ -357,21 +357,21 @@
         "actions": [
           "blacklist_ip"
         ],
-        "reliability": 5
+        "reliability": 10
       },
       {
         "type": "CredentialAccess:RDS/MaliciousIPCaller.SuccessfulLogin",
         "actions": [
           "blacklist_ip"
         ],
-        "reliability": 5
+        "reliability": 8
       },
       {
         "type": "CredentialAccess:RDS/MaliciousIPCaller.FailedLogin",
         "actions": [
           "blacklist_ip"
         ],
-        "reliability": 5
+        "reliability": 6
       },
       {
         "type": "Discovery:RDS/MaliciousIPCaller",
@@ -385,14 +385,14 @@
         "actions": [
           "blacklist_ip"
         ],
-        "reliability": 5
+        "reliability": 8
       },
       {
         "type": "CredentialAccess:RDS/TorIPCaller.FailedLogin",
         "actions": [
           "blacklist_ip"
         ],
-        "reliability": 5
+        "reliability": 6
       },
       {
         "type": "Discovery:RDS/TorIPCaller",

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -1,110 +1,336 @@
 import datetime
 import json
 import logging
+import os
 import time
 import uuid
 from inspect import stack
 from socket import gaierror, gethostbyname
+from typing import Any, Dict, List
+import requests
+import ipaddress
 
 import boto3
 
-import slack
+# Use uppercase for environment variable
+slack_web_hook_url = os.environ.get("SLACK_WEB_HOOK_URL")
 
-slack_web_hook_url = (
-    "https://hooks.slack.com/services/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"
-)
+# Use environment variables for table names
+GD_PATROL_TABLE = os.environ.get("GD_PATROL_TABLE", "GDPatrol")
+GD_PATROL_LOCK_TABLE = os.environ.get("GD_PATROL_LOCK_TABLE", "GDPatrol_lock")
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+# Initialize boto3 clients at the top of the script
+ec2_client = boto3.client("ec2")
+dynamodb_client = boto3.client("dynamodb")
+bedrock_client = boto3.client("bedrock-runtime")
 
 # Grabbing the current timestamp for the footer
 ts = time.time()
 st = datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
 
 
-def blacklist_ip(ip_address):
-    import os
+def enhance_message_with_claude(message_data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Enhance the message using Claude Sonnet on AWS Bedrock.
+    """
     try:
-        client = boto3.client("ec2")
-        dynamodb_client = boto3.client('dynamodb')
-        nacls = client.describe_network_acls()
-        for nacl in nacls["NetworkAcls"]:
-            min_rule_id = min(
-                rule["RuleNumber"] for rule in nacl["Entries"] if not rule["Egress"]
-            )
-            if min_rule_id < 1:
-                raise Exception("Rule number is less than 1")
-            target_rule_number = min_rule_id - 1
+        prompt = f"""You are a security expert analyzing a GuardDuty finding. Please analyze this security alert and provide:
+1. A clear, human-friendly explanation of what this alert means
+2. The potential impact and severity of this threat
+3. Specific recommendations for investigation and remediation
+4. Any additional context that would be helpful for the security team
 
-            # Add ip_address to entry nacl
-            try:
-                r = client.create_network_acl_entry(
-                    CidrBlock=f"{ip_address}/32",
-                    Egress=False,
-                    NetworkAclId=nacl["NetworkAclId"],
-                    Protocol="-1",
-                    RuleAction="deny",
-                    RuleNumber=target_rule_number,
-                )
-                logger.info(f"created network_acl rule_number = {target_rule_number}")
-            except Exception:
-                response = dynamodb_client.query(
-                    TableName="GDPatrol",
-                    KeyConditionExpression='#pk = :pk_value',
-                    ExpressionAttributeNames={'#pk': 'network_acl_id'},
-                    ExpressionAttributeValues={':pk_value': {'S': nacl["NetworkAclId"]}}
-                )
-                oldest_item = response["Items"][0]
+Here is the alert data:
+{json.dumps(message_data, indent=2)}
 
-                try:
-                    logger.info(f"deleting network_acl rule_number = {oldest_item['rule_number']['S']}")
-                    client.delete_network_acl_entry(
-                        Egress=False,
-                        DryRun=eval(os.environ['DELETE_NACL_ENTRY_DRY_RUN']),
-                        NetworkAclId=nacl["NetworkAclId"],
-                        RuleNumber=int(oldest_item["rule_number"]['S'])
-                    )
-                    logger.info(f"deleted network_acl rule_number = {oldest_item['rule_number']['S']}")
+Please format your response in a clear, structured way that would be helpful for a security team to understand and act upon."""
 
-                    dynamodb_client.delete_item(
-                        TableName="GDPatrol",
-                        Key={
-                            'network_acl_id': oldest_item["network_acl_id"], 
-                            'created_at': oldest_item["created_at"]
-                        }
-                    )
-                except Exception as e:
-                    logger.error(f"can't delete the item from table: {e}")
+        response = bedrock_client.invoke_model(
+            modelId="anthropic.claude-sonnet-4-6",
+            body=json.dumps(
+                {
+                    "anthropic_version": "bedrock-2023-05-31",
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": 1000,
+                    "temperature": 0.7,
+                    "top_p": 0.9,
+                }
+            ),
+        )
 
-                client.create_network_acl_entry(
-                    CidrBlock=f"{ip_address}/32",
-                    Egress=False,
-                    NetworkAclId=nacl["NetworkAclId"],
-                    Protocol="-1",
-                    RuleAction="deny",
-                    RuleNumber=target_rule_number,
-                )
-                logger.info(f"created network_acl rule_number = {target_rule_number}")
+        response_body = json.loads(response.get("body").read())
+        enhanced_message = response_body["content"][0]["text"]
 
-                # Add target rule_number to DynamoDB table
-                dynamodb_client.put_item(
-                    TableName='GDPatrol', 
-                    Item={
-                        'network_acl_id' :{'S': nacl["NetworkAclId"]},
-                        'created_at': {'S': str(ts)},
-                        'rule_number': {'S': str(target_rule_number)}
-                    }
-                )
-                logger.info(f"added rule_number = {target_rule_number} to dynamodb table")
-                
-            logger.info(
-                "GDPatrol: Successfully executed action {} for ".format(
-                    stack()[0][3], ip_address
-                )
-            )
-        return True
+        # Add the enhanced message to the description
+        message_data["attachments"][0]["fields"].append({"title": "AI Analysis", "value": enhanced_message, "short": False})
+
+        return message_data
     except Exception as e:
-        logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")
+        logger.error(f"Error enhancing message with Claude: {e}")
+        return message_data
+
+
+def publish_message(slack_web_hook_url: str, data: str) -> None:
+    """Publish a message to Slack with AI-enhanced analysis."""
+    try:
+        enhanced_data = enhance_message_with_claude(json.loads(data))
+        requests.post(slack_web_hook_url, data=json.dumps(enhanced_data), timeout=30)
+    except Exception as e:
+        logger.error(f"Error publishing message to Slack: {e}")
+
+
+def create_network_acl_entry(ip_address: str, nacl_id: str, rule_number: int) -> None:
+    """
+    Create a network ACL entry to block the specified IP address.
+    """
+    try:
+        ec2_client.create_network_acl_entry(
+            CidrBlock=f"{ip_address}/32",
+            Egress=False,
+            NetworkAclId=nacl_id,
+            Protocol="-1",
+            RuleAction="deny",
+            RuleNumber=rule_number,
+        )
+        logger.info(f"Created network_acl rule_number = {rule_number} for {nacl_id}")
+    except Exception as error:
+        logger.error(f"Error creating network_acl entry: {error}")
+        raise
+
+
+def delete_oldest_acl_entry(nacl_id: str) -> None:
+    """
+    Delete the oldest ACL entry for a given Network ACL ID.
+    If DynamoDB is empty, fall back to enumerating actual NACL entries from AWS.
+    """
+    try:
+        response = dynamodb_client.query(
+            TableName=GD_PATROL_TABLE,
+            KeyConditionExpression="#pk = :pk_value",
+            ExpressionAttributeNames={"#pk": "network_acl_id"},
+            ExpressionAttributeValues={":pk_value": {"S": nacl_id}},
+        )
+        items = response.get("Items", [])
+        if not items:
+            logger.warning(f"No entries found in DynamoDB for NACL {nacl_id}. Falling back to AWS NACL entries.")
+            nacl = ec2_client.describe_network_acls(NetworkAclIds=[nacl_id])["NetworkAcls"][0]
+            # Only consider deny, ingress rules (Egress=False, RuleAction='deny')
+            deny_rules = [rule for rule in nacl["Entries"] if not rule["Egress"] and rule["RuleAction"] == "deny"]
+            if not deny_rules:
+                logger.warning(f"No deny ingress rules found in NACL {nacl_id}. Nothing to delete.")
+                return
+            # Find the oldest by lowest rule number
+            oldest_rule = min(deny_rules, key=lambda r: r["RuleNumber"])
+            logger.info(f"Deleting fallback network_acl rule_number = {oldest_rule['RuleNumber']} for {nacl_id}")
+            ec2_client.delete_network_acl_entry(
+                Egress=False,
+                DryRun=os.environ.get("DELETE_NACL_ENTRY_DRY_RUN", "False").lower() == "true",
+                NetworkAclId=nacl_id,
+                RuleNumber=oldest_rule["RuleNumber"],
+            )
+            logger.info(f"Deleted fallback network_acl rule_number = {oldest_rule['RuleNumber']} for {nacl_id}")
+            return
+        oldest_item = items[0]
+        logger.info(f"Deleting network_acl rule_number = {oldest_item['rule_number']['S']} for {nacl_id}")
+
+        ec2_client.delete_network_acl_entry(
+            Egress=False,
+            DryRun=os.environ.get("DELETE_NACL_ENTRY_DRY_RUN", "False").lower() == "true",
+            NetworkAclId=nacl_id,
+            RuleNumber=int(oldest_item["rule_number"]["S"]),
+        )
+
+        dynamodb_client.delete_item(
+            TableName=GD_PATROL_TABLE,
+            Key={
+                "network_acl_id": {"S": nacl_id},
+                "created_at": {"S": oldest_item["created_at"]["S"]},
+            },
+        )
+        logger.info(f"Deleted network_acl rule_number = {oldest_item['rule_number']['S']} for {nacl_id}")
+    except Exception as error:
+        logger.error(f"Error deleting the oldest ACL entry: {error}")
+        # Do not raise here; just log the error and continue
+
+
+def acquire_lock(lock_table_name: str, lock_id: str, max_retries: int = 5, retry_delay: int = 2, ttl_seconds: int = 60) -> None:
+    """
+    Acquire a lock from a DynamoDB table. Adds a TTL to avoid deadlocks.
+    """
+    for attempt in range(max_retries):
+        try:
+            response = dynamodb_client.get_item(TableName=lock_table_name, Key={"lock_id": {"S": lock_id}})
+            if "Item" in response:
+                # Check TTL
+                timestamp = int(response["Item"].get("timestamp", {"S": "0"})["S"])
+                if time.time() - timestamp > ttl_seconds:
+                    # Stale lock, delete it
+                    dynamodb_client.delete_item(TableName=lock_table_name, Key={"lock_id": {"S": lock_id}})
+                else:
+                    time.sleep(retry_delay)
+                    continue
+
+            dynamodb_client.put_item(
+                TableName=lock_table_name,
+                Item={
+                    "lock_id": {"S": lock_id},
+                    "timestamp": {"S": str(int(time.time()))},
+                },
+                ConditionExpression="attribute_not_exists(lock_id)",
+            )
+            return
+        except dynamodb_client.exceptions.ConditionalCheckFailedException:
+            time.sleep(retry_delay)
+
+    raise Exception("Unable to acquire lock after multiple attempts")
+
+
+def release_lock(lock_table_name: str, lock_id: str) -> None:
+    """
+    Release a lock in a DynamoDB table.
+    """
+    try:
+        dynamodb_client.delete_item(TableName=lock_table_name, Key={"lock_id": {"S": lock_id}})
+    except Exception as e:
+        logger.error(f"Error releasing lock: {e}")
+
+
+def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = None) -> bool:
+    """
+    Blacklist an IP address by adding it to the network ACLs.
+    """
+    try:
+        # Validate IP address
+        try:
+            ipaddress.ip_address(ip_address)
+        except ValueError:
+            logger.error(f"Invalid IP address: {ip_address}")
+            return False
+
+        # Use env table names if not provided
+        lock_table_name = lock_table_name or GD_PATROL_LOCK_TABLE
+        # Make lock_id resource-specific
+        lock_id = lock_id or f"lock-{ip_address}"
+        acquire_lock(lock_table_name, lock_id)
+
+        # Use paginator for NACLs
+        paginator = ec2_client.get_paginator("describe_network_acls")
+        nacls = []
+        for page in paginator.paginate():
+            nacls.extend(page["NetworkAcls"])
+
+        for nacl in nacls:
+            # Check if IP is already blacklisted in this NACL
+            existing_rule = None
+            for rule in nacl["Entries"]:
+                if not rule["Egress"] and rule["RuleAction"] == "deny" and rule.get("CidrBlock") == f"{ip_address}/32":
+                    existing_rule = rule
+                    break
+
+            if existing_rule:
+                logger.info(
+                    f"IP {ip_address} is already blacklisted in NACL {nacl['NetworkAclId']} with rule {existing_rule['RuleNumber']}"
+                )
+                continue
+
+            # Get all deny rules for this NACL
+            deny_rules = [rule for rule in nacl["Entries"] if not rule["Egress"] and rule["RuleAction"] == "deny"]
+
+            # Check if we're approaching the limit (max 20 rules per direction)
+            if len(deny_rules) >= 19:
+                logger.warning(f"NACL {nacl['NetworkAclId']} has {len(deny_rules)} deny rules, performing aggressive cleanup.")
+                # Sort deny rules by RuleNumber descending (most recent/highest first)
+                deny_rules_sorted = sorted(deny_rules, key=lambda r: r["RuleNumber"], reverse=True)
+                # Keep only the 10 most recent/highest rule numbers
+                rules_to_delete = deny_rules_sorted[10:]
+                for rule in rules_to_delete:
+                    try:
+                        ec2_client.delete_network_acl_entry(
+                            Egress=False,
+                            NetworkAclId=nacl["NetworkAclId"],
+                            RuleNumber=rule["RuleNumber"],
+                        )
+                        logger.info(f"Aggressively deleted deny rule {rule['RuleNumber']} in NACL {nacl['NetworkAclId']}")
+                    except Exception as e:
+                        logger.error(f"Failed to delete deny rule {rule['RuleNumber']}: {e}")
+
+            if not deny_rules:
+                # If no deny rules exist, start with rule number 100
+                target_rule_number = 100
+            else:
+                # Find the minimum rule number among deny rules
+                min_rule_id = min(rule["RuleNumber"] for rule in deny_rules)
+                # If we hit the lower bound, wrap around to a high rule number (e.g., 32700)
+                if min_rule_id <= 2:
+                    logger.warning(f"Rule number {min_rule_id} is too low; wrapping to 32700 for NACL {nacl['NetworkAclId']}")
+                    target_rule_number = 32700
+                    # Delete any existing rule at 32700 before creating
+                    for rule in nacl["Entries"]:
+                        if not rule["Egress"] and rule["RuleAction"] == "deny" and rule["RuleNumber"] == 32700:
+                            try:
+                                ec2_client.delete_network_acl_entry(
+                                    Egress=False,
+                                    NetworkAclId=nacl["NetworkAclId"],
+                                    RuleNumber=32700,
+                                )
+                                logger.info(f"Deleted existing deny rule 32700 in NACL {nacl['NetworkAclId']}")
+                            except Exception as e:
+                                logger.error(f"Failed to delete existing rule 32700: {e}")
+                    # (Do not continue; proceed to create the new rule at 32700)
+                else:
+                    target_rule_number = min_rule_id - 1
+
+            try:
+                create_network_acl_entry(ip_address, nacl["NetworkAclId"], target_rule_number)
+
+                # Store the new entry in DynamoDB
+                dynamodb_client.put_item(
+                    TableName=GD_PATROL_TABLE,
+                    Item={
+                        "network_acl_id": {"S": nacl["NetworkAclId"]},
+                        "created_at": {"S": str(time.time())},
+                        "rule_number": {"S": str(target_rule_number)},
+                    },
+                )
+
+                logger.info(f"Successfully blacklisted IP: {ip_address}")
+                return True
+
+            except Exception as error:
+                logger.info(f"INFO: {error}")
+                if "NetworkAclEntryLimitExceeded" in str(error):
+                    try:
+                        logger.info(f"Network ACL limit exceeded for {nacl['NetworkAclId']}, attempting to delete oldest entry")
+                        delete_oldest_acl_entry(nacl["NetworkAclId"])
+                        # Retry creating the entry after deleting the oldest one
+                        create_network_acl_entry(ip_address, nacl["NetworkAclId"], target_rule_number)
+                        # Store the new entry in DynamoDB
+                        dynamodb_client.put_item(
+                            TableName=GD_PATROL_TABLE,
+                            Item={
+                                "network_acl_id": {"S": nacl["NetworkAclId"]},
+                                "created_at": {"S": str(time.time())},
+                                "rule_number": {"S": str(target_rule_number)},
+                            },
+                        )
+                        logger.info(f"Successfully blacklisted IP: {ip_address} after deleting oldest entry")
+                        return True
+                    except Exception as retry_error:
+                        logger.error(f"Failed to create entry after deleting oldest: {retry_error}")
+                        # Try the next NACL instead of continuing with the same one
+                        break
+                else:
+                    logger.error(f"Error creating network_acl entry: {error}")
+                    continue
+    except Exception as e:
+        logger.error(f"Error executing blacklist_ip: {e}")
+        return False
+    finally:
+        release_lock(lock_table_name, lock_id)
+    return False
 
 
 def whitelist_ip(ip_address):
@@ -113,17 +339,13 @@ def whitelist_ip(ip_address):
         nacls = client.describe_network_acls()
         for nacl in nacls["NetworkAcls"]:
             for rule in nacl["Entries"]:
-                if rule["CidrBlock"] == f"{ip_address}/32":
+                if rule.get("CidrBlock") == f"{ip_address}/32":
                     client.delete_network_acl_entry(
                         NetworkAclId=nacl["NetworkAclId"],
                         Egress=rule["Egress"],
                         RuleNumber=rule["RuleNumber"],
                     )
-        logger.info(
-            "GDPatrol: Successfully executed action {} for {}".format(
-                stack()[0][3], ip_address
-            )
-        )
+        logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {ip_address}")
         return True
 
     except Exception as e:
@@ -159,11 +381,7 @@ def quarantine_instance(instance_id, vpc_id):
         # NOTE: Assign security group to instance
         client.modify_instance_attribute(InstanceId=instance_id, Groups=[sg_id])
 
-        logger.info(
-            "GDPatrol: Successfully executed action {} for {}".format(
-                stack()[0][3], instance_id
-            )
-        )
+        logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {instance_id}")
         return True
     except Exception as e:
         logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")
@@ -174,19 +392,13 @@ def snapshot_instance(instance_id):
     try:
         client = boto3.client("ec2")
         instance_described = client.describe_instances(InstanceIds=[instance_id])
-        blockmappings = instance_described["Reservations"][0]["Instances"][0][
-            "BlockDeviceMappings"
-        ]
+        blockmappings = instance_described["Reservations"][0]["Instances"][0]["BlockDeviceMappings"]
         for device in blockmappings:
-            snapshot = client.create_snapshot(
+            client.create_snapshot(
                 VolumeId=device["Ebs"]["VolumeId"],
                 Description=f"Created by GDpatrol for {instance_id}",
             )
-        logger.info(
-            "GDPatrol: Successfully executed action {} for {}".format(
-                stack()[0][3], instance_id
-            )
-        )
+        logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {instance_id}")
         return True
     except Exception as e:
         logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")
@@ -199,15 +411,9 @@ def disable_account(username):
         client.put_user_policy(
             UserName=username,
             PolicyName="BlockAllPolicy",
-            PolicyDocument='{"Version":"2012-10-17", "Statement"'
-            ':{"Effect":"Deny", "Action":"*", '
-            '"Resource":"*"}}',
+            PolicyDocument='{"Version":"2012-10-17", "Statement":{"Effect":"Deny", "Action":"*", "Resource":"*"}}',
         )
-        logger.info(
-            "GDPatrol: Successfully executed action {} for {}".format(
-                stack()[0][3], username
-            )
-        )
+        logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {username}")
         return True
     except Exception as e:
         logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")
@@ -220,15 +426,9 @@ def disable_ec2_access(username):
         client.put_user_policy(
             UserName=username,
             PolicyName="BlockEC2Policy",
-            PolicyDocument='{"Version":"2012-10-17", "Statement"'
-            ':{"Effect":"Deny", "Action":"ec2:*" , '
-            '"Resource":"*"}}',
+            PolicyDocument='{"Version":"2012-10-17", "Statement":{"Effect":"Deny", "Action":"ec2:*" , "Resource":"*"}}',
         )
-        logger.info(
-            "GDPatrol: Successfully executed action {} for {}".format(
-                stack()[0][3], username
-            )
-        )
+        logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {username}")
         return True
     except Exception as e:
         logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")
@@ -242,11 +442,7 @@ def enable_ec2_access(username):
             UserName=username,
             PolicyName="BlockEC2Policy",
         )
-        logger.info(
-            "GDPatrol: Successfully executed action {} for {}".format(
-                stack()[0][3], username
-            )
-        )
+        logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {username}")
         return True
     except Exception as e:
         logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")
@@ -267,11 +463,7 @@ def disable_sg_access(username):
             '"ec2:RevokeSecurityGroupEgress" ], '
             '"Resource":"*"}}',
         )
-        logger.info(
-            "GDPatrol: Successfully executed action {} for {}".format(
-                stack()[0][3], username
-            )
-        )
+        logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {username}")
         return True
     except Exception as e:
         logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")
@@ -285,11 +477,7 @@ def enable_sg_access(username):
             UserName=username,
             PolicyName="BlockSecurityGroupPolicy",
         )
-        logger.info(
-            "GDPatrol: Successfully executed action {} for {}".format(
-                stack()[0][3], username
-            )
-        )
+        logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {username}")
         return True
     except Exception as e:
         logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")
@@ -299,9 +487,7 @@ def enable_sg_access(username):
 def asg_detach_instance(instance_id):
     try:
         client = boto3.client("autoscaling")
-        response = client.describe_auto_scaling_instances(
-            InstanceIds=[instance_id], MaxRecords=1
-        )
+        response = client.describe_auto_scaling_instances(InstanceIds=[instance_id], MaxRecords=1)
         asg_name = None
         instances = response["AutoScalingInstances"]
         if instances:
@@ -313,11 +499,7 @@ def asg_detach_instance(instance_id):
                 AutoScalingGroupName=asg_name,
                 ShouldDecrementDesiredCapacity=False,
             )
-        logger.info(
-            "GDPatrol: Successfully executed action {} for {}".format(
-                stack()[0][3], instance_id
-            )
-        )
+        logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {instance_id}")
         return True
     except Exception as e:
         logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")
@@ -325,51 +507,43 @@ def asg_detach_instance(instance_id):
 
 
 class Config:
-    def __init__(self, finding_type):
+    def __init__(self, finding_type: str) -> None:
         self.finding_type = finding_type
-        self.actions = []
-        self.reliability = 0
+        with open("config.json") as f:
+            self.config = json.load(f)
 
-    def get_actions(self):
-        with open("config.json") as config:
-            jsonloads = json.loads(config.read())
-            for item in jsonloads["playbooks"]["playbook"]:
-                if item["type"] == self.finding_type:
-                    self.actions = item["actions"]
-                    return self.actions
+    def get_actions(self) -> List[str]:
+        for playbook in self.config["playbooks"]["playbook"]:
+            if playbook["type"] == self.finding_type:
+                return playbook["actions"] if isinstance(playbook["actions"], list) else [playbook["actions"]]
+        return []
 
-    def get_reliability(self):
-        with open("config.json") as config:
-            jsonloads = json.loads(config.read())
-            for item in jsonloads["playbooks"]["playbook"]:
-                if item["type"] == self.finding_type:
-                    self.reliability = int(item["reliability"])
-                    return self.reliability
+    def get_reliability(self) -> int:
+        for playbook in self.config["playbooks"]["playbook"]:
+            if playbook["type"] == self.finding_type:
+                return playbook["reliability"]
+        return 5
 
 
-def lambda_handler(event, context):
+def lambda_handler(event: Dict[str, Any], context: Any) -> None:
     logger.info(f"GDPatrol: Received JSON event - {event}")
     try:
-
-        finding_id = event["id"]
-        finding_type = event["type"]
-        logger.info(
-            "GDPatrol: Parsed Finding ID: {} - Finding Type: {}".format(
-                finding_id, finding_type
-            )
-        )
+        finding_id = event.get("id")
+        finding_type = event.get("type")
+        if not finding_id or not finding_type:
+            logger.error("Missing required fields in event: 'id' or 'type'")
+            return
+        logger.info(f"GDPatrol: Parsed Finding ID: {finding_id} - Finding Type: {finding_type}")
         config = Config(event["type"])
-        severity = int(event["severity"])
-        count = event["service"]["count"]
+        severity = int(event.get("severity", 0))
+        count = event.get("service", {}).get("count", 0)
 
         config_actions = config.get_actions()
         config_reliability = config.get_reliability()
-        resource_type = event["resource"]["resourceType"]
+        resource_type = event.get("resource", {}).get("resourceType")
     except KeyError as e:
-        logger.error(
-            "GDPatrol: Could not parse the Finding fields correctly, please verify that the JSON is correct"
-        )
-        exit(1)
+        logger.error(f"GDPatrol: Could not parse the Finding fields correctly, please verify that the JSON is correct. {e}")
+        return
     if resource_type == "Instance":
         instance = event["resource"]["instanceDetails"]
         instance_id = instance["instanceId"]
@@ -377,20 +551,21 @@ def lambda_handler(event, context):
     elif resource_type == "AccessKey":
         username = event["resource"]["accessKeyDetails"]["userName"]
 
-    if event["service"]["action"]["actionType"] == "DNS_REQUEST":
-        domain = event["service"]["action"]["dnsRequestAction"]["domain"]
-    elif event["service"]["action"]["actionType"] == "AWS_API_CALL":
-        ip_address = event["service"]["action"]["awsApiCallAction"]["remoteIpDetails"][
-            "ipAddressV4"
-        ]
-    elif event["service"]["action"]["actionType"] == "NETWORK_CONNECTION":
-        ip_address = event["service"]["action"]["networkConnectionAction"][
-            "remoteIpDetails"
-        ]["ipAddressV4"]
-    elif event["service"]["action"]["actionType"] == "PORT_PROBE":
-        ip_address = event["service"]["action"]["portProbeAction"]["portProbeDetails"][
-            0
-        ]["remoteIpDetails"]["ipAddressV4"]
+    action_type = event.get("service", {}).get("action", {}).get("actionType")
+    ip_address = None
+    domain = None
+    if action_type == "DNS_REQUEST":
+        domain = event["service"]["action"]["dnsRequestAction"].get("domain")
+    elif action_type == "AWS_API_CALL":
+        ip_address = event["service"]["action"]["awsApiCallAction"].get("remoteIpDetails", {}).get("ipAddressV4")
+    elif action_type == "NETWORK_CONNECTION":
+        ip_address = event["service"]["action"]["networkConnectionAction"].get("remoteIpDetails", {}).get("ipAddressV4")
+    elif action_type == "PORT_PROBE":
+        port_probe_details = event["service"]["action"]["portProbeAction"].get("portProbeDetails", [])
+        if port_probe_details:
+            ip_address = port_probe_details[0].get("remoteIpDetails", {}).get("ipAddressV4")
+    elif action_type == "RDS_LOGIN_ATTEMPT":
+        ip_address = event["service"]["action"]["rdsLoginAttemptAction"].get("remoteIpDetails", {}).get("ipAddressV4")
 
     successful_actions = 0
     total_config_actions = len(config_actions)
@@ -473,6 +648,8 @@ def lambda_handler(event, context):
                 result = asg_detach_instance(instance_id)
                 successful_actions += int(result)
 
+    logger.info(f"GDPatrol: Executed {successful_actions}/{actions_to_be_executed} actions successfully.")
+
     event_description = event["description"]
     event_account = event["accountId"]
     event_region = event["region"]
@@ -481,16 +658,10 @@ def lambda_handler(event, context):
     event_first_seen = event["service"]["eventFirstSeen"]
     event_last_seen = event["service"]["eventLastSeen"]
     event_type = event["type"]
-    event_id = event["id"]
+    # event_id = event["id"]
 
     # Adding link to finding in the description
-    event_description += "GDPatrol: Total actions: {} - Actions to be executed: {} - Successful Actions: {} - Finding ID:  {} - Finding Type: {}".format(
-        total_config_actions,
-        actions_to_be_executed,
-        successful_actions,
-        finding_id,
-        finding_type,
-    )
+    event_description += f"GDPatrol: Total actions: {total_config_actions} - Actions to be executed: {actions_to_be_executed} - Successful Actions: {successful_actions} - Finding ID:  {finding_id} - Finding Type: {finding_type}"
 
     guardduty_finding = {
         "attachments": [
@@ -521,14 +692,36 @@ def lambda_handler(event, context):
         ]
     }
     # slack.slack_post(event)
-    if event_severity >= 5:
-        slack.publish_message(slack_web_hook_url, json.dumps(guardduty_finding))
+    if event_severity > 5:
+        publish_message(slack_web_hook_url, json.dumps(guardduty_finding))
     logger.info(
-        "GDPatrol: Total actions: {} - Actions to be executed: {} - Successful Actions: {} - Finding ID:  {} - Finding Type: {}".format(
-            total_config_actions,
-            actions_to_be_executed,
-            successful_actions,
-            finding_id,
-            finding_type,
-        )
+        f"GDPatrol: Total actions: {total_config_actions} - Actions to be executed: {actions_to_be_executed} - Successful Actions: {successful_actions} - Finding ID:  {finding_id} - Finding Type: {finding_type}"
     )
+
+
+def create_lock_table():
+    dynamodb = boto3.resource("dynamodb")
+    table_name = "GDPatrol_lock"
+
+    # Check if the table already exists
+    try:
+        table = dynamodb.Table(table_name)
+        if table.table_status not in ["CREATING", "UPDATING", "DELETING", "ACTIVE"]:
+            return
+        logger.info(f"Table '{table_name}' already exists.")
+    except dynamodb.meta.client.exceptions.ResourceNotFoundException:
+        pass  # Table does not exist, proceed with creation
+
+    # Create the table
+    table = dynamodb.create_table(
+        TableName=table_name,
+        KeySchema=[{"AttributeName": "lock_id", "KeyType": "HASH"}],  # Partition key
+        AttributeDefinitions=[
+            {"AttributeName": "lock_id", "AttributeType": "S"}  # String
+        ],
+        ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
+    )
+
+    # Wait until the table exists, this will block until the table is created
+    table.meta.client.get_waiter("table_exists").wait(TableName=table_name)
+    logger.info(f"Table '{table_name}' created successfully.")

--- a/deploy.py
+++ b/deploy.py
@@ -24,19 +24,14 @@ def run():
     iam = boto3.client("iam")
     # delete the role if it already exists, so it can be deployed with
     # the latest configuration
-        
-    for response in iam.get_paginator('list_roles').paginate():
-        for role in response['Roles']:
+
+    for response in iam.get_paginator("list_roles").paginate():
+        for role in response["Roles"]:
             if role["RoleName"] == "GDPatrolRole":
-                iam.delete_role_policy(
-                    RoleName="GDPatrolRole", 
-                    PolicyName="GDPatrol_lambda_policy"
-                )
+                iam.delete_role_policy(RoleName="GDPatrolRole", PolicyName="GDPatrol_lambda_policy")
                 iam.delete_role(RoleName="GDPatrolRole")
 
-    created_role = iam.create_role(
-        RoleName="GDPatrolRole", AssumeRolePolicyDocument=assume_role_policy
-    )
+    created_role = iam.create_role(RoleName="GDPatrolRole", AssumeRolePolicyDocument=assume_role_policy)
     lambda_role_arn = created_role["Role"]["Arn"]
 
     iam.put_role_policy(
@@ -51,41 +46,29 @@ def run():
         gd = boto3.client("guardduty", region_name=region)
         if not gd.list_detectors()["DetectorIds"]:
             created_detector = gd.create_detector(Enable=True)
-            print(
-                "Created GuardDuty detector: {}".format(created_detector["DetectorId"])
-            )
+            print("Created GuardDuty detector: {}".format(created_detector["DetectorId"]))
         else:
             # gd.update_detector(
             #     DetectorId=gd.list_detectors()["DetectorIds"][0], Enable=True
             # )
-            print(
-                "Detector already exists: {}".format(
-                    gd.list_detectors()["DetectorIds"][0]
-                )
-            )
+            print("Detector already exists: {}".format(gd.list_detectors()["DetectorIds"][0]))
 
         try:
             lmb.get_function(FunctionName="GDPatrol")
             lmb.delete_function(FunctionName="GDPatrol")
-        except:
+        except Exception:
             pass
-        sleep(7) # Lambda bug: create function right after the role deleted will cause AccessDeniedExceptionKMS error
+        sleep(7)  # Lambda bug: create function right after the role deleted will cause AccessDeniedExceptionKMS error
         lambda_response = lmb.create_function(
             FunctionName="GDPatrol",
-            Runtime="python3.11",
+            Runtime="python3.14",
             Role=lambda_role_arn,
             Handler="lambda_function.lambda_handler",
-            Layers=[
-                f"arn:aws:lambda:{region}:{sts.get_caller_identity()['Account']}:layer:slack:1"
-            ],
+            Layers=[f"arn:aws:lambda:{region}:{sts.get_caller_identity()['Account']}:layer:slack:1"],
             Code={"ZipFile": open(zipped, "rb").read()},
             Timeout=300,
             MemorySize=128,
-            Environment={
-                'Variables': {
-                    'DELETE_NACL_ENTRY_DRY_RUN': 'False'
-                }
-            },
+            Environment={"Variables": {"DELETE_NACL_ENTRY_DRY_RUN": "False"}},
         )
         target_arn = lambda_response["FunctionArn"]
         target_id = "Id" + str(randrange(10**11, 10**12))
@@ -116,42 +99,37 @@ def run():
             Principal="events.amazonaws.com",
             SourceArn=created_rule["RuleArn"],
         )
-        print(
-            "Successfully deployed the GDPatrol lambda function in region {}.".format(
-                str(region)
-            )
-        )
+        print("Successfully deployed the GDPatrol lambda function in region {}.".format(str(region)))
 
         # Create DynamoDB table if not existed
-        dynamodb_client = boto3.client('dynamodb', region_name=region)
+        dynamodb_client = boto3.client("dynamodb", region_name=region)
         try:
             response = dynamodb_client.create_table(
                 AttributeDefinitions=[
                     {
-                        'AttributeName': 'network_acl_id',
-                        'AttributeType': 'S',
+                        "AttributeName": "network_acl_id",
+                        "AttributeType": "S",
                     },
                     {
-                        'AttributeName': 'created_at',
-                        'AttributeType': 'S',
+                        "AttributeName": "created_at",
+                        "AttributeType": "S",
                     },
                 ],
                 KeySchema=[
                     {
-                        'AttributeName': 'network_acl_id',
-                        'KeyType': 'HASH',
+                        "AttributeName": "network_acl_id",
+                        "KeyType": "HASH",
                     },
                     {
-                        'AttributeName': 'created_at',
-                        'KeyType': 'RANGE',
+                        "AttributeName": "created_at",
+                        "KeyType": "RANGE",
                     },
                 ],
-                BillingMode='PAY_PER_REQUEST',
-                TableName='GDPatrol',
+                BillingMode="PAY_PER_REQUEST",
+                TableName="GDPatrol",
             )
         except dynamodb_client.exceptions.ResourceInUseException:
             pass
-
 
     remove(zipped)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "gdpatrol"
+version = "1.0.0"
+requires-python = ">=3.14"
+
+[tool.ruff]
+target-version = "py314"
+line-length = 140
+exclude = ["slack.py"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F"]
+ignore = ["E501", "E203"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,141 @@
+import pytest
+import boto3
+from moto import mock_aws
+from unittest.mock import MagicMock
+import os
+
+
+@pytest.fixture
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+
+@pytest.fixture
+def sample_guardduty_event():
+    """Sample GuardDuty event for testing."""
+    return {
+        "id": "test-finding-id",
+        "type": "Backdoor:EC2/C&CActivity.B!DNS",
+        "severity": 7,
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "resource": {
+            "resourceType": "Instance",
+            "instanceDetails": {
+                "instanceId": "i-1234567890abcdef0",
+                "networkInterfaces": [{"vpcId": "vpc-12345678"}],
+            },
+        },
+        "service": {
+            "action": {
+                "actionType": "DNS_REQUEST",
+                "dnsRequestAction": {"domain": "malicious.example.com"},
+            },
+            "count": 1,
+            "eventFirstSeen": "2024-01-01T00:00:00Z",
+            "eventLastSeen": "2024-01-01T00:00:00Z",
+        },
+        "description": "Test finding description",
+    }
+
+
+@pytest.fixture
+def sample_rds_guardduty_event():
+    """Sample RDS GuardDuty event for testing."""
+    return {
+        "id": "test-rds-finding-id",
+        "type": "Discovery:RDS/MaliciousIPCaller",
+        "severity": 5,
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "resource": {
+            "resourceType": "RDSDBInstance",
+            "rdsDbInstanceDetails": {
+                "dbInstanceIdentifier": "testdb",
+                "dbClusterIdentifier": "test-cluster",
+                "engine": "Aurora MySQL",
+            },
+        },
+        "service": {
+            "action": {
+                "actionType": "RDS_LOGIN_ATTEMPT",
+                "rdsLoginAttemptAction": {
+                    "remoteIpDetails": {
+                        "ipAddressV4": "203.0.113.50",
+                        "organization": {
+                            "asn": "12345",
+                            "asnOrg": "Test Org",
+                            "isp": "Test ISP",
+                            "org": "Test Org",
+                        },
+                    }
+                },
+            },
+            "count": 1,
+            "eventFirstSeen": "2024-01-01T00:00:00Z",
+            "eventLastSeen": "2024-01-01T00:00:00Z",
+        },
+        "description": "Test RDS finding description",
+    }
+
+
+@pytest.fixture
+def sample_ssh_bruteforce_event():
+    """Sample SSH brute force event with high severity + reliability."""
+    return {
+        "id": "test-ssh-finding-id",
+        "type": "UnauthorizedAccess:EC2/SSHBruteForce",
+        "severity": 8,
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "resource": {
+            "resourceType": "Instance",
+            "instanceDetails": {
+                "instanceId": "i-1234567890abcdef0",
+                "networkInterfaces": [{"vpcId": "vpc-12345678"}],
+            },
+        },
+        "service": {
+            "action": {
+                "actionType": "NETWORK_CONNECTION",
+                "networkConnectionAction": {
+                    "remoteIpDetails": {"ipAddressV4": "198.51.100.99"},
+                },
+            },
+            "count": 500,
+            "eventFirstSeen": "2024-01-01T00:00:00Z",
+            "eventLastSeen": "2024-01-01T00:00:00Z",
+        },
+        "description": "SSH brute force attempt",
+    }
+
+
+@pytest.fixture
+def mock_ec2_client(aws_credentials):
+    """Mocked EC2 client."""
+    with mock_aws():
+        yield boto3.client("ec2")
+
+
+@pytest.fixture
+def mock_dynamodb_client(aws_credentials):
+    """Mocked DynamoDB client."""
+    with mock_aws():
+        yield boto3.client("dynamodb")
+
+
+@pytest.fixture
+def mock_bedrock_response():
+    """Mock Bedrock response in Messages API format."""
+    return {"body": MagicMock(read=lambda: b'{"content": [{"text": "Test AI analysis: This alert indicates suspicious activity."}]}')}
+
+
+@pytest.fixture
+def mock_slack_webhook(monkeypatch):
+    """Mock Slack webhook URL."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -1,0 +1,40 @@
+{
+  "playbooks": {
+    "playbook": [
+      {
+        "type": "Backdoor:EC2/C&CActivity.B!DNS",
+        "actions": [
+          "blacklist_domain",
+          "asg_detach_instance",
+          "quarantine_instance",
+          "snapshot_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Backdoor:EC2/Spambot",
+        "actions": [
+          "blacklist_ip",
+          "asg_detach_instance",
+          "quarantine_instance",
+          "snapshot_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Discovery:RDS/MaliciousIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Recon:EC2/PortProbeUnprotectedPort",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      }
+    ]
+  }
+} 

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -1,0 +1,564 @@
+import pytest
+import json
+from unittest.mock import patch, MagicMock
+import sys
+import os
+from pathlib import Path
+
+# Add the parent directory to sys.path to import the lambda function
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from GDPatrol.lambda_function import (
+    enhance_message_with_claude,
+    publish_message,
+    create_network_acl_entry,
+    delete_oldest_acl_entry,
+    acquire_lock,
+    release_lock,
+    blacklist_ip,
+    whitelist_ip,
+    quarantine_instance,
+    snapshot_instance,
+    disable_account,
+    disable_ec2_access,
+    enable_ec2_access,
+    disable_sg_access,
+    enable_sg_access,
+    Config,
+    lambda_handler,
+)
+
+
+def test_config_class():
+    """Test the Config class functionality."""
+    test_config_path = Path(__file__).parent / "test_config.json"
+
+    with patch("builtins.open", MagicMock()) as mock_open:
+        mock_open.return_value.__enter__.return_value.read.return_value = test_config_path.read_text()
+
+        config = Config("Backdoor:EC2/C&CActivity.B!DNS")
+
+        actions = config.get_actions()
+        assert isinstance(actions, list)
+        assert "blacklist_domain" in actions
+        assert "quarantine_instance" in actions
+
+        reliability = config.get_reliability()
+        assert isinstance(reliability, int)
+        assert reliability == 5
+
+
+def test_config_unknown_finding_type():
+    """Test Config with an unknown finding type returns defaults."""
+    test_config_path = Path(__file__).parent / "test_config.json"
+    with patch("builtins.open", MagicMock()) as mock_open:
+        mock_open.return_value.__enter__.return_value.read.return_value = test_config_path.read_text()
+        config = Config("InvalidFindingType")
+        assert config.get_actions() == []
+        assert config.get_reliability() == 5
+
+
+@patch("GDPatrol.lambda_function.bedrock_client")
+def test_enhance_message_with_claude(mock_bedrock):
+    """Test that enhance_message_with_claude calls Bedrock and appends AI Analysis."""
+    test_message = {"attachments": [{"fields": [{"title": "Test", "value": "Test Value"}]}]}
+
+    mock_bedrock.invoke_model.return_value = {
+        "body": MagicMock(read=lambda: json.dumps({"content": [{"text": "This is a security analysis."}]}).encode())
+    }
+
+    result = enhance_message_with_claude(test_message)
+
+    mock_bedrock.invoke_model.assert_called_once()
+    call_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
+    assert call_body["anthropic_version"] == "bedrock-2023-05-31"
+    assert len(call_body["messages"]) == 1
+    assert call_body["messages"][0]["role"] == "user"
+
+    field_titles = [f["title"] for f in result["attachments"][0]["fields"]]
+    assert "AI Analysis" in field_titles
+    ai_field = next(f for f in result["attachments"][0]["fields"] if f["title"] == "AI Analysis")
+    assert ai_field["value"] == "This is a security analysis."
+
+
+@patch("GDPatrol.lambda_function.bedrock_client")
+def test_enhance_message_with_claude_error_returns_original(mock_bedrock):
+    """Test that Bedrock errors don't break the message — returns original."""
+    test_message = {"attachments": [{"fields": [{"title": "Test", "value": "Test Value"}]}]}
+    mock_bedrock.invoke_model.side_effect = Exception("Bedrock unavailable")
+
+    result = enhance_message_with_claude(test_message)
+
+    assert result == test_message
+    assert len(result["attachments"][0]["fields"]) == 1
+
+
+@patch("GDPatrol.lambda_function.enhance_message_with_claude")
+@patch("requests.post")
+def test_publish_message(mock_post, mock_enhance):
+    """Test Slack message publishing calls enhance then posts."""
+    mock_enhance.return_value = {"attachments": [{"fields": []}]}
+
+    publish_message(
+        "https://hooks.slack.com/services/test",
+        json.dumps({"attachments": [{"fields": []}]}),
+    )
+
+    mock_enhance.assert_called_once()
+    mock_post.assert_called_once()
+
+
+def test_create_network_acl_entry(mock_ec2_client):
+    """Test network ACL entry creation."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    nacl = mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+
+    create_network_acl_entry("10.0.0.1", nacl["NetworkAcl"]["NetworkAclId"], 100)
+
+    nacl_entries = mock_ec2_client.describe_network_acls(NetworkAclIds=[nacl["NetworkAcl"]["NetworkAclId"]])["NetworkAcls"][0]["Entries"]
+
+    assert any(
+        entry["RuleNumber"] == 100 and entry["CidrBlock"] == "10.0.0.1/32" and entry["RuleAction"] == "deny" for entry in nacl_entries
+    )
+
+
+def create_lock_table(dynamodb_client):
+    dynamodb_client.create_table(
+        TableName="GDPatrol_lock",
+        KeySchema=[{"AttributeName": "lock_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "lock_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def create_gdpatrol_table(dynamodb_client):
+    dynamodb_client.create_table(
+        TableName="GDPatrol",
+        KeySchema=[
+            {"AttributeName": "network_acl_id", "KeyType": "HASH"},
+            {"AttributeName": "created_at", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "network_acl_id", "AttributeType": "S"},
+            {"AttributeName": "created_at", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def test_blacklist_ip(mock_ec2_client, mock_dynamodb_client):
+    """Test IP blacklisting functionality."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+
+    result = blacklist_ip("10.0.0.1")
+    assert result is True
+
+
+@patch("boto3.client")
+def test_lambda_handler_ec2_finding(
+    mock_boto3_client,
+    sample_guardduty_event,
+    mock_ec2_client,
+    mock_dynamodb_client,
+    mock_bedrock_response,
+    monkeypatch,
+):
+    """Test the lambda handler with an EC2 finding."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test/webhook")
+
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+
+    mock_bedrock = MagicMock()
+    mock_boto3_client.return_value = mock_bedrock
+    mock_bedrock.invoke_model.return_value = mock_bedrock_response
+
+    test_config_path = Path(__file__).parent / "test_config.json"
+    with patch("builtins.open", MagicMock()) as mock_open, patch("GDPatrol.lambda_function.publish_message") as mock_publish:
+        mock_open.return_value.__enter__.return_value.read.return_value = test_config_path.read_text()
+        lambda_handler(sample_guardduty_event, None)
+        mock_publish.assert_called()
+
+
+def test_lambda_handler_rds_finding(
+    sample_rds_guardduty_event,
+    monkeypatch,
+):
+    """Test the lambda handler correctly extracts IP from RDS_LOGIN_ATTEMPT events."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")
+
+    test_config_path = Path(__file__).parent / "test_config.json"
+    with (
+        patch("builtins.open", MagicMock()) as mock_open,
+        patch("GDPatrol.lambda_function.publish_message"),
+        patch("GDPatrol.lambda_function.blacklist_ip") as mock_blacklist,
+    ):
+        mock_open.return_value.__enter__.return_value.read.return_value = test_config_path.read_text()
+        # RDS finding with severity 5 + reliability 5 = 10, won't execute
+        lambda_handler(sample_rds_guardduty_event, None)
+        mock_blacklist.assert_not_called()
+
+        # Bump severity so it triggers (severity 8 + reliability 5 = 13 > 10)
+        sample_rds_guardduty_event["severity"] = 8
+        lambda_handler(sample_rds_guardduty_event, None)
+        mock_blacklist.assert_called_once_with("203.0.113.50")
+
+
+def test_lambda_handler_missing_fields():
+    """Test lambda handler handles missing required fields gracefully."""
+    bad_event = {"foo": "bar"}
+    # Should not raise
+    lambda_handler(bad_event, None)
+
+
+@patch("boto3.client")
+@pytest.mark.parametrize(
+    "ip_address,expected",
+    [
+        ("10.0.0.1", True),
+        ("192.168.1.1", True),
+        ("invalid-ip", False),
+    ],
+)
+def test_blacklist_ip_parameterized(mock_boto3_client, ip_address, expected, mock_ec2_client, mock_dynamodb_client):
+    """Parameterized test for blacklist_ip function."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+
+    if expected:
+        assert blacklist_ip(ip_address) is True
+    else:
+        assert blacklist_ip(ip_address) is False
+
+
+# --- delete_oldest_acl_entry tests ---
+
+
+@patch("GDPatrol.lambda_function.dynamodb_client")
+@patch("GDPatrol.lambda_function.ec2_client")
+def test_delete_oldest_acl_entry_from_dynamodb(mock_ec2, mock_dynamo):
+    """Test deleting oldest ACL entry when DynamoDB has entries."""
+    mock_dynamo.query.return_value = {
+        "Items": [
+            {
+                "network_acl_id": {"S": "acl-123"},
+                "created_at": {"S": "1000.0"},
+                "rule_number": {"S": "50"},
+            }
+        ]
+    }
+
+    delete_oldest_acl_entry("acl-123")
+
+    mock_ec2.delete_network_acl_entry.assert_called_once()
+    mock_dynamo.delete_item.assert_called_once()
+
+
+@patch("GDPatrol.lambda_function.dynamodb_client")
+@patch("GDPatrol.lambda_function.ec2_client")
+def test_delete_oldest_acl_entry_fallback_to_aws(mock_ec2, mock_dynamo):
+    """Test fallback to AWS NACL entries when DynamoDB is empty."""
+    mock_dynamo.query.return_value = {"Items": []}
+    mock_ec2.describe_network_acls.return_value = {
+        "NetworkAcls": [
+            {
+                "Entries": [
+                    {"Egress": False, "RuleAction": "deny", "RuleNumber": 10, "CidrBlock": "1.2.3.4/32"},
+                    {"Egress": False, "RuleAction": "deny", "RuleNumber": 20, "CidrBlock": "5.6.7.8/32"},
+                    {"Egress": False, "RuleAction": "allow", "RuleNumber": 100, "CidrBlock": "0.0.0.0/0"},
+                ]
+            }
+        ]
+    }
+
+    delete_oldest_acl_entry("acl-123")
+
+    mock_ec2.delete_network_acl_entry.assert_called_once()
+    call_kwargs = mock_ec2.delete_network_acl_entry.call_args[1]
+    assert call_kwargs["RuleNumber"] == 10  # lowest deny rule
+
+
+@patch("GDPatrol.lambda_function.dynamodb_client")
+@patch("GDPatrol.lambda_function.ec2_client")
+def test_delete_oldest_acl_entry_no_deny_rules(mock_ec2, mock_dynamo):
+    """Test fallback when no deny rules exist — should do nothing."""
+    mock_dynamo.query.return_value = {"Items": []}
+    mock_ec2.describe_network_acls.return_value = {
+        "NetworkAcls": [
+            {
+                "Entries": [
+                    {"Egress": False, "RuleAction": "allow", "RuleNumber": 100, "CidrBlock": "0.0.0.0/0"},
+                ]
+            }
+        ]
+    }
+
+    delete_oldest_acl_entry("acl-123")
+
+    mock_ec2.delete_network_acl_entry.assert_not_called()
+
+
+# --- Lock tests ---
+
+
+@patch("GDPatrol.lambda_function.dynamodb_client")
+def test_acquire_and_release_lock(mock_dynamo):
+    """Test acquiring and releasing a lock."""
+    mock_dynamo.get_item.return_value = {}  # no existing lock
+    mock_dynamo.exceptions = MagicMock()
+    mock_dynamo.exceptions.ConditionalCheckFailedException = type("ConditionalCheckFailedException", (Exception,), {})
+
+    acquire_lock("GDPatrol_lock", "test-lock")
+    mock_dynamo.put_item.assert_called_once()
+
+    release_lock("GDPatrol_lock", "test-lock")
+    mock_dynamo.delete_item.assert_called_once()
+
+
+# --- whitelist_ip tests ---
+
+
+def test_whitelist_ip(mock_ec2_client):
+    """Test whitelisting (removing) an IP from NACLs."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    nacl = mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    nacl_id = nacl["NetworkAcl"]["NetworkAclId"]
+
+    # Add a deny rule first
+    mock_ec2_client.create_network_acl_entry(
+        CidrBlock="192.168.1.1/32",
+        Egress=False,
+        NetworkAclId=nacl_id,
+        Protocol="-1",
+        RuleAction="deny",
+        RuleNumber=100,
+    )
+
+    result = whitelist_ip("192.168.1.1")
+    assert result is True
+
+    # Verify the rule was removed
+    entries = mock_ec2_client.describe_network_acls(NetworkAclIds=[nacl_id])["NetworkAcls"][0]["Entries"]
+    assert not any(e.get("CidrBlock") == "192.168.1.1/32" and e["RuleAction"] == "deny" for e in entries)
+
+
+# --- IAM action tests ---
+
+
+def test_disable_account(mock_ec2_client, aws_credentials):
+    """Test disabling an IAM account."""
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        iam = boto3.client("iam", region_name="us-east-1")
+        iam.create_user(UserName="testuser")
+        result = disable_account("testuser")
+        assert result is True
+
+        policies = iam.list_user_policies(UserName="testuser")
+        assert "BlockAllPolicy" in policies["PolicyNames"]
+
+
+def test_disable_ec2_access(aws_credentials):
+    """Test disabling EC2 access for a user."""
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        iam = boto3.client("iam", region_name="us-east-1")
+        iam.create_user(UserName="testuser")
+        result = disable_ec2_access("testuser")
+        assert result is True
+
+        policies = iam.list_user_policies(UserName="testuser")
+        assert "BlockEC2Policy" in policies["PolicyNames"]
+
+
+def test_enable_ec2_access(aws_credentials):
+    """Test re-enabling EC2 access by removing the block policy."""
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        iam = boto3.client("iam", region_name="us-east-1")
+        iam.create_user(UserName="testuser")
+        # First disable
+        disable_ec2_access("testuser")
+        # Then enable
+        result = enable_ec2_access("testuser")
+        assert result is True
+
+        policies = iam.list_user_policies(UserName="testuser")
+        assert "BlockEC2Policy" not in policies["PolicyNames"]
+
+
+def test_disable_sg_access(aws_credentials):
+    """Test disabling security group access."""
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        iam = boto3.client("iam", region_name="us-east-1")
+        iam.create_user(UserName="testuser")
+        result = disable_sg_access("testuser")
+        assert result is True
+
+        policies = iam.list_user_policies(UserName="testuser")
+        assert "BlockSecurityGroupPolicy" in policies["PolicyNames"]
+
+
+def test_enable_sg_access(aws_credentials):
+    """Test re-enabling security group access."""
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        iam = boto3.client("iam", region_name="us-east-1")
+        iam.create_user(UserName="testuser")
+        disable_sg_access("testuser")
+        result = enable_sg_access("testuser")
+        assert result is True
+
+        policies = iam.list_user_policies(UserName="testuser")
+        assert "BlockSecurityGroupPolicy" not in policies["PolicyNames"]
+
+
+# --- EC2 action tests ---
+
+
+def test_quarantine_instance(mock_ec2_client):
+    """Test quarantining an EC2 instance."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    subnet = mock_ec2_client.create_subnet(VpcId=vpc["Vpc"]["VpcId"], CidrBlock="10.0.1.0/24")
+    instance = mock_ec2_client.run_instances(
+        ImageId="ami-12345678",
+        MinCount=1,
+        MaxCount=1,
+        SubnetId=subnet["Subnet"]["SubnetId"],
+    )
+    instance_id = instance["Instances"][0]["InstanceId"]
+
+    result = quarantine_instance(instance_id, vpc["Vpc"]["VpcId"])
+    assert result is True
+
+    # Verify instance has a quarantine security group
+    instance_desc = mock_ec2_client.describe_instances(InstanceIds=[instance_id])
+    sgs = instance_desc["Reservations"][0]["Instances"][0]["SecurityGroups"]
+    assert any("Quarantine" in sg["GroupName"] for sg in sgs)
+
+
+def test_snapshot_instance(mock_ec2_client):
+    """Test snapshotting an EC2 instance's volumes."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    subnet = mock_ec2_client.create_subnet(VpcId=vpc["Vpc"]["VpcId"], CidrBlock="10.0.1.0/24")
+    instance = mock_ec2_client.run_instances(
+        ImageId="ami-12345678",
+        MinCount=1,
+        MaxCount=1,
+        SubnetId=subnet["Subnet"]["SubnetId"],
+    )
+    instance_id = instance["Instances"][0]["InstanceId"]
+
+    result = snapshot_instance(instance_id)
+    assert result is True
+
+
+# --- lambda_handler action dispatch tests ---
+
+
+def test_lambda_handler_blacklist_ip_count_threshold(monkeypatch):
+    """Test that blacklist_ip triggers on count > 100 even when severity + reliability <= 10."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")
+
+    event = {
+        "id": "test-id",
+        "type": "Recon:EC2/PortProbeUnprotectedPort",
+        "severity": 2,
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "resource": {
+            "resourceType": "Instance",
+            "instanceDetails": {
+                "instanceId": "i-abc",
+                "networkInterfaces": [{"vpcId": "vpc-abc"}],
+            },
+        },
+        "service": {
+            "action": {
+                "actionType": "PORT_PROBE",
+                "portProbeAction": {"portProbeDetails": [{"remoteIpDetails": {"ipAddressV4": "1.2.3.4"}}]},
+            },
+            "count": 200,
+            "eventFirstSeen": "2024-01-01T00:00:00Z",
+            "eventLastSeen": "2024-01-01T00:00:00Z",
+        },
+        "description": "Port probe",
+    }
+
+    test_config_path = Path(__file__).parent / "test_config.json"
+    with (
+        patch("builtins.open", MagicMock()) as mock_open,
+        patch("GDPatrol.lambda_function.publish_message"),
+        patch("GDPatrol.lambda_function.blacklist_ip") as mock_blacklist,
+    ):
+        mock_open.return_value.__enter__.return_value.read.return_value = test_config_path.read_text()
+        mock_blacklist.return_value = True
+        lambda_handler(event, None)
+        # severity 2 + reliability 5 = 7, not > 10, but count 200 > 100
+        mock_blacklist.assert_called_once_with("1.2.3.4")
+
+
+def test_lambda_handler_iam_finding(monkeypatch):
+    """Test lambda handler with an IAM AccessKey finding dispatches disable_account."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")
+
+    event = {
+        "id": "test-iam-id",
+        "type": "Recon:IAMUser/MaliciousIPCaller",
+        "severity": 8,
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "resource": {
+            "resourceType": "AccessKey",
+            "accessKeyDetails": {"userName": "baduser"},
+        },
+        "service": {
+            "action": {
+                "actionType": "AWS_API_CALL",
+                "awsApiCallAction": {
+                    "remoteIpDetails": {"ipAddressV4": "9.8.7.6"},
+                },
+            },
+            "count": 1,
+            "eventFirstSeen": "2024-01-01T00:00:00Z",
+            "eventLastSeen": "2024-01-01T00:00:00Z",
+        },
+        "description": "IAM recon",
+    }
+
+    test_config_path = Path(__file__).parent / "test_config.json"
+    with (
+        patch("builtins.open", MagicMock()) as mock_open,
+        patch("GDPatrol.lambda_function.publish_message"),
+        patch("GDPatrol.lambda_function.disable_account") as mock_disable,
+    ):
+        # Add the IAM finding type to the mock config
+        config_data = json.loads(test_config_path.read_text())
+        config_data["playbooks"]["playbook"].append(
+            {
+                "type": "Recon:IAMUser/MaliciousIPCaller",
+                "actions": ["disable_account"],
+                "reliability": 5,
+            }
+        )
+        mock_open.return_value.__enter__.return_value.read.return_value = json.dumps(config_data)
+        mock_disable.return_value = True
+        lambda_handler(event, None)
+        mock_disable.assert_called_once_with("baduser")


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow with ruff lint/format and pytest (27 tests)
- Replace flakeheaven with ruff for Python 3.14 compatibility
- Restore tests and refactored lambda_function.py from gdpatrol_upgrades branch (Bedrock AI analysis, locking, NACL cleanup, RDS support)
- Update Lambda runtime to python3.14
- Add Dependabot for weekly pip and GitHub Actions dependency updates

## Test plan
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pytest tests/ -v` — 27/27 tests pass
- [ ] GitHub Actions CI runs green on this PR