### PR TITLE
Fix blacklist_ip NACL coverage, lock handling, and missing lock table

### DIFF
--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -27,10 +27,6 @@ ec2_client = boto3.client("ec2")
 dynamodb_client = boto3.client("dynamodb")
 bedrock_client = boto3.client("bedrock-runtime")
 
-# Grabbing the current timestamp for the footer
-ts = time.time()
-st = datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
-
 
 def summarize_event(event: Dict[str, Any]) -> Dict[str, Any]:
     """Extract security-relevant fields from a GuardDuty event."""
@@ -263,21 +259,24 @@ def release_lock(lock_table_name: str, lock_id: str) -> None:
 
 def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = None) -> bool:
     """
-    Blacklist an IP address by adding it to the network ACLs.
+    Blacklist an IP address by adding a deny rule to every network ACL.
+    Returns True only if the IP is blocked in all NACLs.
     """
+    # Validate IP address
     try:
-        # Validate IP address
-        try:
-            ipaddress.ip_address(ip_address)
-        except ValueError:
-            logger.error(f"Invalid IP address: {ip_address}")
-            return False
+        ipaddress.ip_address(ip_address)
+    except ValueError:
+        logger.error(f"Invalid IP address: {ip_address}")
+        return False
 
-        # Use env table names if not provided
-        lock_table_name = lock_table_name or GD_PATROL_LOCK_TABLE
-        # Make lock_id resource-specific
-        lock_id = lock_id or f"lock-{ip_address}"
+    # Use env table names if not provided
+    lock_table_name = lock_table_name or GD_PATROL_LOCK_TABLE
+    # Make lock_id resource-specific
+    lock_id = lock_id or f"lock-{ip_address}"
+    lock_acquired = False
+    try:
         acquire_lock(lock_table_name, lock_id)
+        lock_acquired = True
 
         # Use paginator for NACLs
         paginator = ec2_client.get_paginator("describe_network_acls")
@@ -285,6 +284,7 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
         for page in paginator.paginate():
             nacls.extend(page["NetworkAcls"])
 
+        blocked_count = 0
         for nacl in nacls:
             # Check if IP is already blacklisted in this NACL
             existing_rule = None
@@ -297,6 +297,7 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                 logger.info(
                     f"IP {ip_address} is already blacklisted in NACL {nacl['NetworkAclId']} with rule {existing_rule['RuleNumber']}"
                 )
+                blocked_count += 1
                 continue
 
             # Get all deny rules for this NACL
@@ -305,9 +306,9 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
             # Check if we're approaching the limit (max 20 rules per direction)
             if len(deny_rules) >= 19:
                 logger.warning(f"NACL {nacl['NetworkAclId']} has {len(deny_rules)} deny rules, performing aggressive cleanup.")
-                # Sort deny rules by RuleNumber descending (most recent/highest first)
-                deny_rules_sorted = sorted(deny_rules, key=lambda r: r["RuleNumber"], reverse=True)
-                # Keep only the 10 most recent/highest rule numbers
+                # New rules get decreasing numbers (min - 1), so the lowest rule numbers are the most recent
+                deny_rules_sorted = sorted(deny_rules, key=lambda r: r["RuleNumber"])
+                # Keep only the 10 most recent (lowest) rule numbers
                 rules_to_delete = deny_rules_sorted[10:]
                 for rule in rules_to_delete:
                     try:
@@ -359,8 +360,8 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                     },
                 )
 
-                logger.info(f"Successfully blacklisted IP: {ip_address}")
-                return True
+                logger.info(f"Blacklisted IP {ip_address} in NACL {nacl['NetworkAclId']}")
+                blocked_count += 1
 
             except Exception as error:
                 logger.info(f"INFO: {error}")
@@ -379,21 +380,27 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                                 "rule_number": {"S": str(target_rule_number)},
                             },
                         )
-                        logger.info(f"Successfully blacklisted IP: {ip_address} after deleting oldest entry")
-                        return True
+                        logger.info(f"Blacklisted IP {ip_address} in NACL {nacl['NetworkAclId']} after deleting oldest entry")
+                        blocked_count += 1
                     except Exception as retry_error:
                         logger.error(f"Failed to create entry after deleting oldest: {retry_error}")
-                        # Try the next NACL instead of continuing with the same one
-                        break
+                        # Try the next NACL
+                        continue
                 else:
                     logger.error(f"Error creating network_acl entry: {error}")
                     continue
+
+        if nacls and blocked_count == len(nacls):
+            logger.info(f"Successfully blacklisted IP: {ip_address} in {blocked_count} NACL(s)")
+            return True
+        logger.error(f"Blacklisted IP {ip_address} in only {blocked_count}/{len(nacls)} NACLs")
+        return False
     except Exception as e:
         logger.error(f"Error executing blacklist_ip: {e}")
         return False
     finally:
-        release_lock(lock_table_name, lock_id)
-    return False
+        if lock_acquired:
+            release_lock(lock_table_name, lock_id)
 
 
 def whitelist_ip(ip_address):
@@ -607,6 +614,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
     except KeyError as e:
         logger.error(f"GDPatrol: Could not parse the Finding fields correctly, please verify that the JSON is correct. {e}")
         return
+    instance_id = None
+    vpc_id = None
+    username = None
     if resource_type == "Instance":
         instance = event["resource"]["instanceDetails"]
         instance_id = instance["instanceId"]
@@ -757,6 +767,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
         }
     )
 
+    # Timestamp for the footer, computed per invocation
+    st = datetime.datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S")
     guardduty_finding = {
         "attachments": [
             {

--- a/deploy.py
+++ b/deploy.py
@@ -173,6 +173,27 @@ def run():
         except dynamodb_client.exceptions.ResourceInUseException:
             pass
 
+        # Create the lock table used by blacklist_ip's acquire_lock/release_lock
+        try:
+            response = dynamodb_client.create_table(
+                AttributeDefinitions=[
+                    {
+                        "AttributeName": "lock_id",
+                        "AttributeType": "S",
+                    },
+                ],
+                KeySchema=[
+                    {
+                        "AttributeName": "lock_id",
+                        "KeyType": "HASH",
+                    },
+                ],
+                BillingMode="PAY_PER_REQUEST",
+                TableName="GDPatrol_lock",
+            )
+        except dynamodb_client.exceptions.ResourceInUseException:
+            pass
+
     remove(zipped)
 
 

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -156,6 +156,38 @@ def test_blacklist_ip(mock_ec2_client, mock_dynamodb_client):
     assert result is True
 
 
+def test_blacklist_ip_blocks_all_nacls(mock_ec2_client, mock_dynamodb_client):
+    """blacklist_ip must add a deny rule to every NACL, not just the first one."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+
+    assert blacklist_ip("203.0.113.9") is True
+
+    for nacl in mock_ec2_client.describe_network_acls()["NetworkAcls"]:
+        assert any(not e["Egress"] and e["RuleAction"] == "deny" and e.get("CidrBlock") == "203.0.113.9/32" for e in nacl["Entries"]), (
+            f"IP not blocked in NACL {nacl['NetworkAclId']}"
+        )
+
+
+@patch("GDPatrol.lambda_function.release_lock")
+@patch("GDPatrol.lambda_function.acquire_lock")
+def test_blacklist_ip_no_release_when_acquire_fails(mock_acquire, mock_release):
+    """A failed acquire_lock must not release another invocation's lock."""
+    mock_acquire.side_effect = Exception("Unable to acquire lock after multiple attempts")
+    assert blacklist_ip("198.51.100.1") is False
+    mock_release.assert_not_called()
+
+
+@patch("GDPatrol.lambda_function.release_lock")
+def test_blacklist_ip_invalid_ip_does_not_touch_lock(mock_release):
+    """An invalid IP returns False before any locking happens."""
+    assert blacklist_ip("not-an-ip") is False
+    mock_release.assert_not_called()
+
+
 @patch("boto3.client")
 def test_lambda_handler_ec2_finding(
     mock_boto3_client,


### PR DESCRIPTION
## Summary

Repo review turned up several correctness bugs in the remediation path. Two of them meant `blacklist_ip` either never worked (fresh deploy) or only partially worked (multi-NACL environments).

### Fixes

- **`blacklist_ip` only blocked the IP in the first NACL.** It returned `True` inside the NACL loop after the first successful rule creation, leaving every other NACL open. It now processes all NACLs and returns `True` only when the IP is blocked in each of them. Also fixed a `break` that exited the loop where the comment said "try the next NACL".
- **Lock released even when never acquired.** A failed `acquire_lock` (or an invalid IP) still ran `release_lock` in the `finally` block — deleting a *competing invocation's* lock, or calling DynamoDB with `TableName=None` on the invalid-IP path. The lock is now only released if it was acquired, and IP validation happens before any locking.
- **`GDPatrol_lock` table was never created.** `deploy.py` created the `GDPatrol` table but not the lock table, so on a fresh deployment `acquire_lock` raised `ResourceNotFoundException` and every `blacklist_ip` call failed. `deploy.py` now creates it. (Note: `create_lock_table()` in `lambda_function.py` is dead code that nothing calls — left in place, but it could be removed in a follow-up.)
- **Aggressive NACL cleanup kept the oldest rules and deleted the newest.** New rules get decreasing rule numbers (`min - 1`), so sorting descending and keeping the first 10 kept the *highest* numbers — the oldest rules — while deleting the most recent blocks. Now sorts ascending to keep the 10 most recent.
- **`NameError` risk in `lambda_handler`.** `instance_id`/`vpc_id`/`username` were only assigned for matching resource types; a playbook action referencing them for a non-matching finding crashed the handler before the Slack notification. They're now initialized to `None` so the action fails gracefully and is counted as unsuccessful.
- **Stale Slack footer timestamp.** The timestamp was computed once at module import (Lambda cold start), so warm invocations reported the wrong time. Now computed per invocation.

### Verified, not changed

- The Bedrock model ID `anthropic.claude-sonnet-4-6` is valid for the `bedrock-runtime` `invoke_model` endpoint per the AWS model card, so it was left as is.

### Follow-up candidates (not in this PR)

- Aggressive cleanup deletes NACL rules from AWS but leaves their DynamoDB entries behind, so the table drifts from reality.
- `whitelist_ip` doesn't paginate `describe_network_acls` and creates its own client instead of using the module-level one.

## Testing

- Added `test_blacklist_ip_blocks_all_nacls`, `test_blacklist_ip_no_release_when_acquire_fails`, and `test_blacklist_ip_invalid_ip_does_not_touch_lock` — all three fail against the previous code and pass with the fixes.
- Full suite: 30 passed. `ruff check` and `ruff format --check` clean.