### PR TITLE
Keep DynamoDB in sync with NACL rules; clean up whitelist_ip; remove dead code

### DIFF
--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -105,7 +105,9 @@ def enhance_message_with_claude(message_data: Dict[str, Any]) -> Dict[str, Any]:
 Alert data:
 {json.dumps(message_data, indent=2)}
 
-Be concise — this will appear in a Slack message."""
+Be concise — this will appear in a Slack message attachment. Format the response as Slack mrkdwn, \
+NOT standard Markdown: *single asterisks* for bold, _underscores_ for italic, hyphen bullets. \
+Slack has no heading syntax — use a short bold line instead of ## headings."""
 
         response = bedrock_client.invoke_model(
             # On-demand invocation requires an inference profile ID, not the bare model ID

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -108,7 +108,8 @@ Alert data:
 Be concise — this will appear in a Slack message."""
 
         response = bedrock_client.invoke_model(
-            modelId="anthropic.claude-sonnet-4-6",
+            # On-demand invocation requires an inference profile ID, not the bare model ID
+            modelId="global.anthropic.claude-sonnet-4-6",
             body=json.dumps(
                 {
                     "anthropic_version": "bedrock-2023-05-31",

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -257,6 +257,33 @@ def release_lock(lock_table_name: str, lock_id: str) -> None:
         logger.error(f"Error releasing lock: {e}")
 
 
+def delete_dynamodb_rule_entries(nacl_id: str, rule_numbers: set) -> None:
+    """
+    Remove the DynamoDB entries tracking NACL rules that no longer exist in AWS,
+    so the table doesn't drift from the actual NACL state.
+    """
+    if not rule_numbers:
+        return
+    try:
+        response = dynamodb_client.query(
+            TableName=GD_PATROL_TABLE,
+            KeyConditionExpression="#pk = :pk_value",
+            ExpressionAttributeNames={"#pk": "network_acl_id"},
+            ExpressionAttributeValues={":pk_value": {"S": nacl_id}},
+        )
+        for item in response.get("Items", []):
+            if int(item["rule_number"]["S"]) in rule_numbers:
+                dynamodb_client.delete_item(
+                    TableName=GD_PATROL_TABLE,
+                    Key={
+                        "network_acl_id": {"S": nacl_id},
+                        "created_at": {"S": item["created_at"]["S"]},
+                    },
+                )
+    except Exception as e:
+        logger.error(f"Error cleaning up DynamoDB entries for NACL {nacl_id}: {e}")
+
+
 def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = None) -> bool:
     """
     Blacklist an IP address by adding a deny rule to every network ACL.
@@ -310,6 +337,7 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                 deny_rules_sorted = sorted(deny_rules, key=lambda r: r["RuleNumber"])
                 # Keep only the 10 most recent (lowest) rule numbers
                 rules_to_delete = deny_rules_sorted[10:]
+                deleted_rule_numbers = set()
                 for rule in rules_to_delete:
                     try:
                         ec2_client.delete_network_acl_entry(
@@ -317,9 +345,11 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                             NetworkAclId=nacl["NetworkAclId"],
                             RuleNumber=rule["RuleNumber"],
                         )
+                        deleted_rule_numbers.add(rule["RuleNumber"])
                         logger.info(f"Aggressively deleted deny rule {rule['RuleNumber']} in NACL {nacl['NetworkAclId']}")
                     except Exception as e:
                         logger.error(f"Failed to delete deny rule {rule['RuleNumber']}: {e}")
+                delete_dynamodb_rule_entries(nacl["NetworkAclId"], deleted_rule_numbers)
 
             if not deny_rules:
                 # If no deny rules exist, start with rule number 100
@@ -340,6 +370,7 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                                     NetworkAclId=nacl["NetworkAclId"],
                                     RuleNumber=32700,
                                 )
+                                delete_dynamodb_rule_entries(nacl["NetworkAclId"], {32700})
                                 logger.info(f"Deleted existing deny rule 32700 in NACL {nacl['NetworkAclId']}")
                             except Exception as e:
                                 logger.error(f"Failed to delete existing rule 32700: {e}")
@@ -405,16 +436,20 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
 
 def whitelist_ip(ip_address):
     try:
-        client = boto3.client("ec2")
-        nacls = client.describe_network_acls()
-        for nacl in nacls["NetworkAcls"]:
-            for rule in nacl["Entries"]:
-                if rule.get("CidrBlock") == f"{ip_address}/32":
-                    client.delete_network_acl_entry(
-                        NetworkAclId=nacl["NetworkAclId"],
-                        Egress=rule["Egress"],
-                        RuleNumber=rule["RuleNumber"],
-                    )
+        paginator = ec2_client.get_paginator("describe_network_acls")
+        for page in paginator.paginate():
+            for nacl in page["NetworkAcls"]:
+                removed_rule_numbers = set()
+                for rule in nacl["Entries"]:
+                    if rule.get("CidrBlock") == f"{ip_address}/32":
+                        ec2_client.delete_network_acl_entry(
+                            NetworkAclId=nacl["NetworkAclId"],
+                            Egress=rule["Egress"],
+                            RuleNumber=rule["RuleNumber"],
+                        )
+                        if not rule["Egress"]:
+                            removed_rule_numbers.add(rule["RuleNumber"])
+                delete_dynamodb_rule_entries(nacl["NetworkAclId"], removed_rule_numbers)
         logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {ip_address}")
         return True
 
@@ -785,31 +820,3 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
     logger.info(
         f"GDPatrol: Total actions: {total_config_actions} - Actions to be executed: {actions_to_be_executed} - Successful Actions: {successful_actions} - Finding ID:  {finding_id} - Finding Type: {finding_type}"
     )
-
-
-def create_lock_table():
-    dynamodb = boto3.resource("dynamodb")
-    table_name = "GDPatrol_lock"
-
-    # Check if the table already exists
-    try:
-        table = dynamodb.Table(table_name)
-        if table.table_status not in ["CREATING", "UPDATING", "DELETING", "ACTIVE"]:
-            return
-        logger.info(f"Table '{table_name}' already exists.")
-    except dynamodb.meta.client.exceptions.ResourceNotFoundException:
-        pass  # Table does not exist, proceed with creation
-
-    # Create the table
-    table = dynamodb.create_table(
-        TableName=table_name,
-        KeySchema=[{"AttributeName": "lock_id", "KeyType": "HASH"}],  # Partition key
-        AttributeDefinitions=[
-            {"AttributeName": "lock_id", "AttributeType": "S"}  # String
-        ],
-        ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
-    )
-
-    # Wait until the table exists, this will block until the table is created
-    table.meta.client.get_waiter("table_exists").wait(TableName=table_name)
-    logger.info(f"Table '{table_name}' created successfully.")

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -115,8 +115,8 @@ Be concise — this will appear in a Slack message."""
                     "anthropic_version": "bedrock-2023-05-31",
                     "messages": [{"role": "user", "content": prompt}],
                     "max_tokens": 1000,
+                    # Claude 4.x rejects requests that set both temperature and top_p
                     "temperature": 0.7,
-                    "top_p": 0.9,
                 }
             ),
         )

--- a/deploy.py
+++ b/deploy.py
@@ -1,3 +1,4 @@
+import argparse
 import subprocess
 import tempfile
 from os import environ, remove
@@ -50,7 +51,7 @@ def build_function_zip() -> str:
     return zipped
 
 
-def run():
+def run(slack_web_hook_url=None):
     regions = []
     ec2 = boto3.client("ec2")
     response = ec2.describe_regions()
@@ -86,8 +87,9 @@ def run():
     # Pass the Slack webhook through to the function; without it the Lambda
     # logs "Error publishing message to Slack" and no notification is sent
     lambda_env = {"DELETE_NACL_ENTRY_DRY_RUN": "False"}
-    if environ.get("SLACK_WEB_HOOK_URL"):
-        lambda_env["SLACK_WEB_HOOK_URL"] = environ["SLACK_WEB_HOOK_URL"]
+    slack_web_hook_url = slack_web_hook_url or environ.get("SLACK_WEB_HOOK_URL")
+    if slack_web_hook_url:
+        lambda_env["SLACK_WEB_HOOK_URL"] = slack_web_hook_url
     else:
         print("WARNING: SLACK_WEB_HOOK_URL is not set; Slack notifications will fail.")
 
@@ -206,4 +208,11 @@ def run():
 
 
 if __name__ == "__main__":
-    run()
+    parser = argparse.ArgumentParser(description="Deploy GDPatrol to all enabled regions")
+    parser.add_argument(
+        "--slack-webhook-url",
+        default=None,
+        help="Slack incoming webhook URL for notifications (falls back to the SLACK_WEB_HOOK_URL environment variable)",
+    )
+    args = parser.parse_args()
+    run(slack_web_hook_url=args.slack_webhook_url)

--- a/deploy.py
+++ b/deploy.py
@@ -112,16 +112,27 @@ def run(slack_web_hook_url=None):
         except Exception:
             pass
         sleep(7)  # Lambda bug: create function right after the role deleted will cause AccessDeniedExceptionKMS error
-        lambda_response = lmb.create_function(
-            FunctionName="GDPatrol",
-            Runtime=LAMBDA_RUNTIME,
-            Role=lambda_role_arn,
-            Handler="lambda_function.lambda_handler",
-            Code={"ZipFile": open(zipped, "rb").read()},
-            Timeout=300,
-            MemorySize=128,
-            Environment={"Variables": lambda_env},
-        )
+        # A freshly recreated IAM role can take a while to propagate, and
+        # create_function intermittently fails with "The role defined for the
+        # function cannot be assumed by Lambda" until it does — retry with backoff.
+        for attempt in range(5):
+            try:
+                lambda_response = lmb.create_function(
+                    FunctionName="GDPatrol",
+                    Runtime=LAMBDA_RUNTIME,
+                    Role=lambda_role_arn,
+                    Handler="lambda_function.lambda_handler",
+                    Code={"ZipFile": open(zipped, "rb").read()},
+                    Timeout=300,
+                    MemorySize=128,
+                    Environment={"Variables": lambda_env},
+                )
+                break
+            except lmb.exceptions.InvalidParameterValueException as e:
+                if "cannot be assumed" not in str(e) or attempt == 4:
+                    raise
+                print("Role not yet assumable in region {}, retrying...".format(str(region)))
+                sleep(10)
         target_arn = lambda_response["FunctionArn"]
         target_id = "Id" + str(randrange(10**11, 10**12))
 

--- a/deploy.py
+++ b/deploy.py
@@ -1,6 +1,6 @@
 import subprocess
 import tempfile
-from os import remove
+from os import environ, remove
 from pathlib import Path
 from random import randrange
 from shutil import copy2, copytree, make_archive, rmtree
@@ -83,6 +83,14 @@ def run():
         PolicyDocument=lambda_policy,
     )
 
+    # Pass the Slack webhook through to the function; without it the Lambda
+    # logs "Error publishing message to Slack" and no notification is sent
+    lambda_env = {"DELETE_NACL_ENTRY_DRY_RUN": "False"}
+    if environ.get("SLACK_WEB_HOOK_URL"):
+        lambda_env["SLACK_WEB_HOOK_URL"] = environ["SLACK_WEB_HOOK_URL"]
+    else:
+        print("WARNING: SLACK_WEB_HOOK_URL is not set; Slack notifications will fail.")
+
     for region in regions:
         lmb = boto3.client("lambda", region_name=region)
         cw_events = boto3.client("events", region_name=region)
@@ -110,7 +118,7 @@ def run():
             Code={"ZipFile": open(zipped, "rb").read()},
             Timeout=300,
             MemorySize=128,
-            Environment={"Variables": {"DELETE_NACL_ENTRY_DRY_RUN": "False"}},
+            Environment={"Variables": lambda_env},
         )
         target_arn = lambda_response["FunctionArn"]
         target_id = "Id" + str(randrange(10**11, 10**12))

--- a/lambda_policy.json
+++ b/lambda_policy.json
@@ -60,7 +60,8 @@
         "bedrock:InvokeModel"
       ],
       "Resource": [
-        "arn:aws:bedrock:*:*:foundation-model/anthropic.claude-sonnet-4-6"
+        "arn:aws:bedrock:*:*:foundation-model/anthropic.claude-sonnet-4-6",
+        "arn:aws:bedrock:*:*:inference-profile/global.anthropic.claude-sonnet-4-6"
       ]
     }
   ]

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -73,6 +73,7 @@ def test_enhance_message_with_claude(mock_bedrock):
     assert mock_bedrock.invoke_model.call_args[1]["modelId"] == "global.anthropic.claude-sonnet-4-6"
     call_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
     assert call_body["anthropic_version"] == "bedrock-2023-05-31"
+    assert "top_p" not in call_body  # temperature and top_p are mutually exclusive on Claude 4.x
     assert len(call_body["messages"]) == 1
     assert call_body["messages"][0]["role"] == "user"
 

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -70,6 +70,7 @@ def test_enhance_message_with_claude(mock_bedrock):
     result = enhance_message_with_claude(test_message)
 
     mock_bedrock.invoke_model.assert_called_once()
+    assert mock_bedrock.invoke_model.call_args[1]["modelId"] == "global.anthropic.claude-sonnet-4-6"
     call_body = json.loads(mock_bedrock.invoke_model.call_args[1]["body"])
     assert call_body["anthropic_version"] == "bedrock-2023-05-31"
     assert len(call_body["messages"]) == 1

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -12,6 +12,7 @@ from GDPatrol.lambda_function import (
     publish_message,
     create_network_acl_entry,
     delete_oldest_acl_entry,
+    delete_dynamodb_rule_entries,
     acquire_lock,
     release_lock,
     blacklist_ip,
@@ -186,6 +187,40 @@ def test_blacklist_ip_invalid_ip_does_not_touch_lock(mock_release):
     """An invalid IP returns False before any locking happens."""
     assert blacklist_ip("not-an-ip") is False
     mock_release.assert_not_called()
+
+
+def test_whitelist_ip_cleans_dynamodb(mock_ec2_client, mock_dynamodb_client):
+    """Whitelisting an IP also removes the DynamoDB entries for the deleted rules."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+
+    assert blacklist_ip("203.0.113.77") is True
+    assert mock_dynamodb_client.scan(TableName="GDPatrol")["Count"] > 0
+
+    assert whitelist_ip("203.0.113.77") is True
+    assert mock_dynamodb_client.scan(TableName="GDPatrol")["Count"] == 0
+
+
+def test_delete_dynamodb_rule_entries(mock_dynamodb_client):
+    """Only the entries matching the deleted rule numbers are removed."""
+    create_gdpatrol_table(mock_dynamodb_client)
+    for created_at, rule_number in [("100.0", "50"), ("200.0", "60")]:
+        mock_dynamodb_client.put_item(
+            TableName="GDPatrol",
+            Item={
+                "network_acl_id": {"S": "acl-123"},
+                "created_at": {"S": created_at},
+                "rule_number": {"S": rule_number},
+            },
+        )
+
+    delete_dynamodb_rule_entries("acl-123", {50})
+
+    items = mock_dynamodb_client.scan(TableName="GDPatrol")["Items"]
+    assert len(items) == 1
+    assert items[0]["rule_number"]["S"] == "60"
 
 
 @patch("boto3.client")


### PR DESCRIPTION
## Summary

Follow-ups from the review in #12.

- **DynamoDB drift.** Several paths deleted NACL deny rules from AWS but left their tracking entries in the `GDPatrol` table: `blacklist_ip`'s aggressive cleanup, its rule-32700 wrap-around, and `whitelist_ip`. The stale entries meant `delete_oldest_acl_entry` could later target rules that no longer exist (and its DynamoDB delete never runs when the NACL delete fails, so the stale "oldest" item wedges the cleanup permanently). A new `delete_dynamodb_rule_entries(nacl_id, rule_numbers)` helper removes the tracking entries whenever rules are deleted, in all three paths.
- **`whitelist_ip` cleanup.** Now uses the module-level `ec2_client` (matching every other NACL function) and paginates `describe_network_acls` instead of reading one unpaginated page, so it can't miss NACLs in large accounts.
- **Dead code removal.** Dropped the unused `create_lock_table()` from `lambda_function.py` — nothing ever called it, and since #12 `deploy.py` provisions the lock table.

## Testing

- Added `test_whitelist_ip_cleans_dynamodb` (blacklist → whitelist leaves the table empty) and `test_delete_dynamodb_rule_entries` (only entries matching the deleted rule numbers are removed).
- Full suite: 32 passed. `ruff check` and `ruff format --check` clean.