### PR TITLE
Harden NACL/DynamoDB cleanup edge cases

### DIFF
--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -268,21 +268,27 @@ def delete_dynamodb_rule_entries(nacl_id: str, rule_numbers: set) -> None:
     if not rule_numbers:
         return
     try:
-        response = dynamodb_client.query(
+        paginator = dynamodb_client.get_paginator("query")
+        for page in paginator.paginate(
             TableName=GD_PATROL_TABLE,
             KeyConditionExpression="#pk = :pk_value",
             ExpressionAttributeNames={"#pk": "network_acl_id"},
             ExpressionAttributeValues={":pk_value": {"S": nacl_id}},
-        )
-        for item in response.get("Items", []):
-            if int(item["rule_number"]["S"]) in rule_numbers:
-                dynamodb_client.delete_item(
-                    TableName=GD_PATROL_TABLE,
-                    Key={
-                        "network_acl_id": {"S": nacl_id},
-                        "created_at": {"S": item["created_at"]["S"]},
-                    },
-                )
+        ):
+            for item in page.get("Items", []):
+                # Skip legacy/malformed items so one bad row doesn't abort the cleanup
+                try:
+                    rule_number = int(item["rule_number"]["S"])
+                except KeyError, ValueError:
+                    continue
+                if rule_number in rule_numbers:
+                    dynamodb_client.delete_item(
+                        TableName=GD_PATROL_TABLE,
+                        Key={
+                            "network_acl_id": {"S": nacl_id},
+                            "created_at": {"S": item["created_at"]["S"]},
+                        },
+                    )
     except Exception as e:
         logger.error(f"Error cleaning up DynamoDB entries for NACL {nacl_id}: {e}")
 
@@ -439,22 +445,32 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
 
 def whitelist_ip(ip_address):
     try:
+        all_deleted = True
         paginator = ec2_client.get_paginator("describe_network_acls")
         for page in paginator.paginate():
             for nacl in page["NetworkAcls"]:
                 removed_rule_numbers = set()
                 for rule in nacl["Entries"]:
                     if rule.get("CidrBlock") == f"{ip_address}/32":
-                        ec2_client.delete_network_acl_entry(
-                            NetworkAclId=nacl["NetworkAclId"],
-                            Egress=rule["Egress"],
-                            RuleNumber=rule["RuleNumber"],
-                        )
+                        # Per-rule handling: a failed delete (e.g. a concurrent run already
+                        # removed it) must not stop the DynamoDB cleanup for rules that
+                        # were successfully deleted, or the table drifts again
+                        try:
+                            ec2_client.delete_network_acl_entry(
+                                NetworkAclId=nacl["NetworkAclId"],
+                                Egress=rule["Egress"],
+                                RuleNumber=rule["RuleNumber"],
+                            )
+                        except Exception as e:
+                            logger.error(f"GDPatrol: Error deleting rule {rule['RuleNumber']} in NACL {nacl['NetworkAclId']}: {e}")
+                            all_deleted = False
+                            continue
                         if not rule["Egress"]:
                             removed_rule_numbers.add(rule["RuleNumber"])
                 delete_dynamodb_rule_entries(nacl["NetworkAclId"], removed_rule_numbers)
-        logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {ip_address}")
-        return True
+        if all_deleted:
+            logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {ip_address}")
+        return all_deleted
 
     except Exception as e:
         logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")

--- a/lambda_policy.json
+++ b/lambda_policy.json
@@ -60,7 +60,7 @@
         "bedrock:InvokeModel"
       ],
       "Resource": [
-        "arn:aws:bedrock:*:*:foundation-model/anthropic.claude-sonnet-4-6",
+        "arn:aws:bedrock:*:*:foundation-model/anthropic.claude-sonnet-4-6*",
         "arn:aws:bedrock:*:*:inference-profile/global.anthropic.claude-sonnet-4-6"
       ]
     }

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 # Add the parent directory to sys.path to import the lambda function
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import GDPatrol.lambda_function as lambda_module
 from GDPatrol.lambda_function import (
     enhance_message_with_claude,
     publish_message,
@@ -223,6 +224,53 @@ def test_delete_dynamodb_rule_entries(mock_dynamodb_client):
     items = mock_dynamodb_client.scan(TableName="GDPatrol")["Items"]
     assert len(items) == 1
     assert items[0]["rule_number"]["S"] == "60"
+
+
+def test_delete_dynamodb_rule_entries_skips_malformed_items(mock_dynamodb_client):
+    """A legacy item without rule_number must not abort cleanup of valid items after it."""
+    create_gdpatrol_table(mock_dynamodb_client)
+    # created_at "100.0" sorts before "50.0" lexicographically, so the malformed
+    # item is encountered first
+    mock_dynamodb_client.put_item(
+        TableName="GDPatrol",
+        Item={"network_acl_id": {"S": "acl-123"}, "created_at": {"S": "100.0"}},
+    )
+    mock_dynamodb_client.put_item(
+        TableName="GDPatrol",
+        Item={"network_acl_id": {"S": "acl-123"}, "created_at": {"S": "50.0"}, "rule_number": {"S": "50"}},
+    )
+
+    delete_dynamodb_rule_entries("acl-123", {50})
+
+    items = mock_dynamodb_client.scan(TableName="GDPatrol")["Items"]
+    assert len(items) == 1
+    assert "rule_number" not in items[0]
+
+
+def test_whitelist_ip_partial_failure_still_cleans_dynamodb(mock_ec2_client, mock_dynamodb_client, monkeypatch):
+    """One failed rule delete reports failure but doesn't block cleanup for the rest."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+
+    assert blacklist_ip("203.0.113.88") is True
+    assert mock_dynamodb_client.scan(TableName="GDPatrol")["Count"] >= 2
+
+    real_delete = lambda_module.ec2_client.delete_network_acl_entry
+    calls = {"count": 0}
+
+    def flaky_delete(**kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise Exception("InvalidNetworkAclEntry.NotFound")
+        return real_delete(**kwargs)
+
+    monkeypatch.setattr(lambda_module.ec2_client, "delete_network_acl_entry", flaky_delete)
+
+    assert whitelist_ip("203.0.113.88") is False
+    # Only the rule whose delete failed keeps its DynamoDB entry
+    assert mock_dynamodb_client.scan(TableName="GDPatrol")["Count"] == 1
 
 
 @patch("boto3.client")


### PR DESCRIPTION
Follow-ups from the PR #13 review — edge-case hardening, no behavior change on the happy path.

## Changes

- **`delete_dynamodb_rule_entries`**: paginate the DynamoDB query (previously only the first 1MB page was examined, so a badly drifted table couldn't be fully cleaned) and skip legacy items missing `rule_number` instead of letting a `KeyError` abort cleanup of the remaining items.
- **`whitelist_ip`**: per-rule error handling. A failed `delete_network_acl_entry` (e.g. a concurrent invocation already removed the rule) no longer aborts the loop before the DynamoDB cleanup runs — which would have reintroduced exactly the drift PR #13 fixed. The function still returns `False` when any delete fails.
- **`lambda_policy.json`**: `foundation-model/anthropic.claude-sonnet-4-6*` (trailing wildcard) so InvokeModel stays authorized if the global inference profile ever resolves to a versioned foundation-model ARN in some region.

## Testing

- 34 tests pass; the 2 new tests (`test_delete_dynamodb_rule_entries_skips_malformed_items`, `test_whitelist_ip_partial_failure_still_cleans_dynamodb`) were verified to fail against the pre-fix code.
- ruff check/format clean.

