### PR TITLE
feat: expand GuardDuty finding-type coverage (S3, Lambda, EKS, Runtime, anomalous-behavior)

### DIFF
--- a/GDPatrol/config.json
+++ b/GDPatrol/config.json
@@ -911,6 +911,111 @@
           "asg_detach_instance"
         ],
         "reliability": 5
+      },
+      {
+        "type": "CredentialAccess:Kubernetes/MaliciousIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "CredentialAccess:Kubernetes/MaliciousIPCaller.Custom",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "CredentialAccess:Kubernetes/TorIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "DefenseEvasion:Kubernetes/MaliciousIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "DefenseEvasion:Kubernetes/MaliciousIPCaller.Custom",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "DefenseEvasion:Kubernetes/TorIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Discovery:Kubernetes/MaliciousIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Discovery:Kubernetes/MaliciousIPCaller.Custom",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Discovery:Kubernetes/TorIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:Kubernetes/MaliciousIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:Kubernetes/MaliciousIPCaller.Custom",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:Kubernetes/TorIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Persistence:Kubernetes/MaliciousIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Persistence:Kubernetes/MaliciousIPCaller.Custom",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Persistence:Kubernetes/TorIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
       }
     ]
   }

--- a/GDPatrol/config.json
+++ b/GDPatrol/config.json
@@ -400,6 +400,517 @@
           "blacklist_ip"
         ],
         "reliability": 5
+      },
+      {
+        "type": "Discovery:S3/MaliciousIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Discovery:S3/MaliciousIPCaller.Custom",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Discovery:S3/TorIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Exfiltration:S3/MaliciousIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:S3/MaliciousIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:S3/TorIPCaller",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:S3/MaliciousIPCaller.Custom",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "CredentialAccess:IAMUser/AnomalousBehavior",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "DefenseEvasion:IAMUser/AnomalousBehavior",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "DefenseEvasion:IAMUser/BedrockLoggingDisabled",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Discovery:IAMUser/AnomalousBehavior",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Exfiltration:IAMUser/AnomalousBehavior",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:IAMUser/AnomalousBehavior",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "InitialAccess:IAMUser/AnomalousBehavior",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "PenTest:IAMUser/ParrotLinux",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "PenTest:IAMUser/PentooLinux",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Persistence:IAMUser/AnomalousBehavior",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "PrivilegeEscalation:IAMUser/AnomalousBehavior",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.InsideAWS",
+        "actions": [
+          "disable_account"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "CredentialAccess:IAMUser/CompromisedCredentials",
+        "actions": [
+          "disable_account",
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.OutsideAWS",
+        "actions": [
+          "disable_account",
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:IAMUser/ResourceCredentialExfiltration.OutsideAWS",
+        "actions": [
+          "disable_account",
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Backdoor:EC2/C&CActivity.B",
+        "actions": [
+          "blacklist_ip",
+          "asg_detach_instance",
+          "quarantine_instance",
+          "snapshot_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "CryptoCurrency:EC2/BitcoinTool.B",
+        "actions": [
+          "blacklist_ip",
+          "snapshot_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "DefenseEvasion:EC2/UnusualDNSResolver",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "DefenseEvasion:EC2/UnusualDoHActivity",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "DefenseEvasion:EC2/UnusualDoTActivity",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:EC2/WinRMBruteForce",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Recon:EC2/PortProbeEMRUnprotectedPort",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Backdoor:EC2/DenialOfService.Dns",
+        "actions": [
+          "quarantine_instance",
+          "snapshot_instance",
+          "asg_detach_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Backdoor:EC2/DenialOfService.Tcp",
+        "actions": [
+          "quarantine_instance",
+          "snapshot_instance",
+          "asg_detach_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Backdoor:EC2/DenialOfService.Udp",
+        "actions": [
+          "quarantine_instance",
+          "snapshot_instance",
+          "asg_detach_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Backdoor:EC2/DenialOfService.UdpOnTcpPorts",
+        "actions": [
+          "quarantine_instance",
+          "snapshot_instance",
+          "asg_detach_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Backdoor:EC2/DenialOfService.UnusualProtocol",
+        "actions": [
+          "quarantine_instance",
+          "snapshot_instance",
+          "asg_detach_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:EC2/PortSweep",
+        "actions": [
+          "quarantine_instance",
+          "snapshot_instance",
+          "asg_detach_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:EC2/AbusedDomainRequest.Reputation",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:EC2/MaliciousDomainRequest.Custom",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:EC2/BitcoinDomainRequest.Reputation",
+        "actions": [
+          "blacklist_domain",
+          "asg_detach_instance",
+          "quarantine_instance",
+          "snapshot_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:EC2/MaliciousDomainRequest.Reputation",
+        "actions": [
+          "blacklist_domain",
+          "asg_detach_instance",
+          "quarantine_instance",
+          "snapshot_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:EC2/SuspiciousDomainRequest.Reputation",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 3
+      },
+      {
+        "type": "UnauthorizedAccess:EC2/TorClient",
+        "actions": [
+          "blacklist_ip",
+          "asg_detach_instance",
+          "quarantine_instance",
+          "snapshot_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:EC2/TorRelay",
+        "actions": [
+          "blacklist_ip",
+          "asg_detach_instance",
+          "quarantine_instance",
+          "snapshot_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Backdoor:Lambda/C&CActivity.B",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "CryptoCurrency:Lambda/BitcoinTool.B",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Trojan:Lambda/BlackholeTraffic",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Trojan:Lambda/DropPoint",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:Lambda/MaliciousIPCaller.Custom",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:Lambda/TorClient",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:Lambda/TorRelay",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Backdoor:Runtime/C&CActivity.B",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "CryptoCurrency:Runtime/BitcoinTool.B",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Trojan:Runtime/BlackholeTraffic",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Trojan:Runtime/DropPoint",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:Runtime/TorClient",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "UnauthorizedAccess:Runtime/TorRelay",
+        "actions": [
+          "blacklist_ip"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Backdoor:Runtime/C&CActivity.B!DNS",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "CryptoCurrency:Runtime/BitcoinTool.B!DNS",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Trojan:Runtime/BlackholeTraffic!DNS",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Trojan:Runtime/DropPoint!DNS",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Trojan:Runtime/DGADomainRequest.C!DNS",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Trojan:Runtime/DriveBySourceTraffic!DNS",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Trojan:Runtime/PhishingDomainRequest!DNS",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:Runtime/AbusedDomainRequest.Reputation",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:Runtime/BitcoinDomainRequest.Reputation",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:Runtime/MaliciousDomainRequest.Reputation",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Impact:Runtime/SuspiciousDomainRequest.Reputation",
+        "actions": [
+          "blacklist_domain"
+        ],
+        "reliability": 3
+      },
+      {
+        "type": "Execution:EC2/MaliciousFile",
+        "actions": [
+          "quarantine_instance",
+          "snapshot_instance",
+          "asg_detach_instance"
+        ],
+        "reliability": 5
+      },
+      {
+        "type": "Execution:EC2/SuspiciousFile",
+        "actions": [
+          "quarantine_instance",
+          "snapshot_instance",
+          "asg_detach_instance"
+        ],
+        "reliability": 5
       }
     ]
   }

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -67,6 +67,9 @@ def summarize_event(event: Dict[str, Any]) -> Dict[str, Any]:
     elif action_type == "RDS_LOGIN_ATTEMPT":
         rds_action = action.get("rdsLoginAttemptAction", {})
         summary["source_ip"] = rds_action.get("remoteIpDetails", {}).get("ipAddressV4")
+    elif action_type == "KUBERNETES_API_CALL":
+        k8s_action = action.get("kubernetesApiCallAction", {})
+        summary["source_ip"] = k8s_action.get("remoteIpDetails", {}).get("ipAddressV4")
 
     # Target resource
     resource = event.get("resource", {})
@@ -677,6 +680,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
             ip_address = port_probe_details[0].get("remoteIpDetails", {}).get("ipAddressV4")
     elif action_type == "RDS_LOGIN_ATTEMPT":
         ip_address = event["service"]["action"]["rdsLoginAttemptAction"].get("remoteIpDetails", {}).get("ipAddressV4")
+    elif action_type == "KUBERNETES_API_CALL":
+        ip_address = event["service"]["action"]["kubernetesApiCallAction"].get("remoteIpDetails", {}).get("ipAddressV4")
 
     successful_actions = 0
     total_config_actions = len(config_actions)

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - GuardDuty finding-type coverage for S3 Protection, Lambda Protection, EC2/IAM anomalous-behavior and reputation findings, Runtime Monitoring, and EC2 Malware Protection (68 new playbook entries)
+- Kubernetes/EKS audit-log finding coverage with a new KUBERNETES_API_CALL IP-extraction branch (15 playbook entries)
 - Integration with AWS Bedrock Claude Sonnet for enhanced Slack message processing
 - Comprehensive test suite using pytest for lambda function
 - Mock AWS services using moto for testing

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- GuardDuty finding-type coverage for S3 Protection, Lambda Protection, EC2/IAM anomalous-behavior and reputation findings, Runtime Monitoring, and EC2 Malware Protection (68 new playbook entries)
 - Integration with AWS Bedrock Claude Sonnet for enhanced Slack message processing
 - Comprehensive test suite using pytest for lambda function
 - Mock AWS services using moto for testing

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -631,3 +631,60 @@ def test_lambda_handler_iam_finding(monkeypatch):
         mock_disable.return_value = True
         lambda_handler(event, None)
         mock_disable.assert_called_once_with("baduser")
+
+
+# --- Real config.json integrity ---
+
+# Pre-existing entries that use disable_sg_access/disable_ec2_access — implemented and dispatched in
+# lambda_handler, but outside the 6 actions this coverage work adds new entries with. Left untouched.
+LEGACY_NON_STANDARD_ACTION_TYPES = {
+    "Persistence:IAMUser/NetworkPermissions",
+    "Recon:IAMUser/NetworkPermissions",
+    "ResourceConsumption:IAMUser/ComputeResources",
+}
+
+
+def test_real_config_json_integrity(monkeypatch):
+    """The real GDPatrol/config.json must be valid JSON, have no duplicate finding types, and every
+    newly-added entry must use only the 6 actions lambda_handler actually dispatches. A representative
+    sample of the new finding types must resolve via the Config class to the expected action list."""
+    real_config_path = Path(__file__).parent.parent / "GDPatrol" / "config.json"
+    data = json.loads(real_config_path.read_text())
+
+    playbook = data["playbooks"]["playbook"]
+    types = [p["type"] for p in playbook]
+    assert len(types) == len(set(types)), "duplicate finding types in config.json"
+
+    valid_actions = {
+        "blacklist_ip",
+        "blacklist_domain",
+        "quarantine_instance",
+        "snapshot_instance",
+        "asg_detach_instance",
+        "disable_account",
+    }
+    for p in playbook:
+        if p["type"] in LEGACY_NON_STANDARD_ACTION_TYPES:
+            continue
+        actions = p["actions"] if isinstance(p["actions"], list) else [p["actions"]]
+        for action in actions:
+            assert action in valid_actions, f"unimplemented action {action!r} for finding type {p['type']!r}"
+
+    by_type = {p["type"]: p for p in playbook}
+    expected_actions_by_type = {
+        "Discovery:S3/MaliciousIPCaller": ["blacklist_ip"],
+        "CredentialAccess:IAMUser/CompromisedCredentials": ["disable_account", "blacklist_ip"],
+        "Backdoor:EC2/DenialOfService.Tcp": ["quarantine_instance", "snapshot_instance", "asg_detach_instance"],
+        "Backdoor:Lambda/C&CActivity.B": ["blacklist_ip"],
+        "Trojan:Runtime/DGADomainRequest.C!DNS": ["blacklist_domain"],
+        "Execution:EC2/MaliciousFile": ["quarantine_instance", "snapshot_instance", "asg_detach_instance"],
+    }
+    for finding_type, expected in expected_actions_by_type.items():
+        assert finding_type in by_type, f"missing finding type {finding_type!r}"
+
+    # Config.__init__ opens "config.json" relatively — chdir into GDPatrol/ so it reads the real file
+    # (not mocked), matching the layout of the deployed Lambda package.
+    monkeypatch.chdir(real_config_path.parent)
+    for finding_type, expected in expected_actions_by_type.items():
+        config = Config(finding_type)
+        assert config.get_actions() == expected

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -8,6 +8,7 @@ from pathlib import Path
 # Add the parent directory to sys.path to import the lambda function
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from GDPatrol.lambda_function import (
+    summarize_event,
     enhance_message_with_claude,
     publish_message,
     create_network_acl_entry,
@@ -678,6 +679,7 @@ def test_real_config_json_integrity(monkeypatch):
         "Backdoor:Lambda/C&CActivity.B": ["blacklist_ip"],
         "Trojan:Runtime/DGADomainRequest.C!DNS": ["blacklist_domain"],
         "Execution:EC2/MaliciousFile": ["quarantine_instance", "snapshot_instance", "asg_detach_instance"],
+        "CredentialAccess:Kubernetes/MaliciousIPCaller": ["blacklist_ip"],
     }
     for finding_type, expected in expected_actions_by_type.items():
         assert finding_type in by_type, f"missing finding type {finding_type!r}"
@@ -688,3 +690,69 @@ def test_real_config_json_integrity(monkeypatch):
     for finding_type, expected in expected_actions_by_type.items():
         config = Config(finding_type)
         assert config.get_actions() == expected
+
+
+# --- KUBERNETES_API_CALL extraction ---
+
+
+def test_summarize_event_kubernetes_api_call():
+    """summarize_event must extract the remote IP for KUBERNETES_API_CALL findings."""
+    event = {
+        "type": "CredentialAccess:Kubernetes/MaliciousIPCaller",
+        "severity": 8,
+        "service": {
+            "action": {
+                "actionType": "KUBERNETES_API_CALL",
+                "kubernetesApiCallAction": {
+                    "remoteIpDetails": {"ipAddressV4": "198.51.100.42"},
+                },
+            }
+        },
+    }
+    summary = summarize_event(event)
+    assert summary["source_ip"] == "198.51.100.42"
+
+
+def test_lambda_handler_kubernetes_finding(monkeypatch):
+    """Test lambda handler extracts the IP from a KUBERNETES_API_CALL event and dispatches blacklist_ip."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")
+
+    event = {
+        "id": "test-k8s-id",
+        "type": "CredentialAccess:Kubernetes/MaliciousIPCaller",
+        "severity": 8,
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "resource": {"resourceType": "Kubernetes"},
+        "service": {
+            "action": {
+                "actionType": "KUBERNETES_API_CALL",
+                "kubernetesApiCallAction": {
+                    "remoteIpDetails": {"ipAddressV4": "198.51.100.42"},
+                },
+            },
+            "count": 1,
+            "eventFirstSeen": "2024-01-01T00:00:00Z",
+            "eventLastSeen": "2024-01-01T00:00:00Z",
+        },
+        "description": "Kubernetes API call from known malicious IP",
+    }
+
+    test_config_path = Path(__file__).parent / "test_config.json"
+    with (
+        patch("builtins.open", MagicMock()) as mock_open,
+        patch("GDPatrol.lambda_function.publish_message"),
+        patch("GDPatrol.lambda_function.blacklist_ip") as mock_blacklist,
+    ):
+        config_data = json.loads(test_config_path.read_text())
+        config_data["playbooks"]["playbook"].append(
+            {
+                "type": "CredentialAccess:Kubernetes/MaliciousIPCaller",
+                "actions": ["blacklist_ip"],
+                "reliability": 5,
+            }
+        )
+        mock_open.return_value.__enter__.return_value.read.return_value = json.dumps(config_data)
+        mock_blacklist.return_value = True
+        lambda_handler(event, None)
+        mock_blacklist.assert_called_once_with("198.51.100.42")


### PR DESCRIPTION
## Summary

GDPatrol's playbook (`GDPatrol/config.json`) had drifted well behind AWS's current GuardDuty finding catalog — it covered ~50 mostly-classic EC2/IAM/RDS types while AWS now documents ~200 active types across S3, EKS/Kubernetes, Lambda, Runtime Monitoring, Malware Protection, and anomalous-behavior families. This PR adds **83 new playbook entries** for the finding types GDPatrol can meaningfully auto-remediate today with its existing action set, plus a small handler change to unlock the EKS family.

Researched against AWS's GuardDuty User Guide finding-type pages (current through mid-2026). Only finding types whose data shape a real action can act on were added — an entry whose actions can never fire would be dead weight (the finding already alerts to Slack without one).

### Added — existing actions, config only (68)
- **S3 Protection (7)** — malicious-IP / Tor callers → `blacklist_ip`
- **IAM (15)** — anomalous-behavior, compromised-credentials, credential-exfiltration, new PenTest distros → `disable_account` (+`blacklist_ip` where an external caller IP is present)
- **EC2 (20)** — non-DNS C&C/Bitcoin twins, DNS-over-HTTPS/TLS resolver abuse, reputation domain requests, WinRM brute force, EMR port probe, Tor client/relay, and DoS/port-sweep. **DoS and PortSweep findings deliberately use containment actions only (`quarantine`/`snapshot`/`asg_detach`) — the instance is the attack source and the remote IP is the victim, so blacklisting it would be wrong.**
- **Lambda Protection (7)** — C&C / Bitcoin / blackhole / droppoint / malicious-IP / Tor → `blacklist_ip`
- **Runtime Monitoring (17)** — the IP/domain-carrying subset → `blacklist_ip` / `blacklist_domain`
- **EC2 Malware Protection (2)** — `Execution:EC2/MaliciousFile`, `Execution:EC2/SuspiciousFile` → containment

### Added — EKS/Kubernetes (15 + code)
Kubernetes audit-log findings carry the caller IP under `service.action.kubernetesApiCallAction.remoteIpDetails` (verified against AWS's API reference), but the handler had no `KUBERNETES_API_CALL` branch, so `blacklist_ip` could never fire for them. Added that branch to both `lambda_handler` and `summarize_event`, plus 15 malicious-IP/Tor EKS entries. Fail-safe: if the IP is absent, `blacklist_ip(None)` already returns False and the finding still alerts.

### Deliberately excluded (unsafe with current actions)
- `UnauthorizedAccess:{EC2,Runtime}/MetadataDNSRebind` — the domain resolves to `169.254.169.254`; `blacklist_domain` would NACL-deny IMDS for the whole subnet (self-inflicted outage).
- `Policy:IAMUser/{RootCredentialUsage,ShortTermRootCredentialUsage}` — `disable_account` can't attach a deny policy to the root user.

## Not in this PR (follow-ups)
- ~13 existing entries reference **retired** finding types AWS no longer emits (e.g. `Backdoor:EC2/XORDDOS`, `Persistence:IAMUser/*Permissions`, the bare `UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration`, `UnauthorizedAccess:EC2/TorIPCaller`). They're inert, not harmful — worth a cleanup pass.
- Finding families that need genuinely new remediation actions, not just config: S3 bucket-policy findings (revert public access / re-enable logging), container/ECS malicious-file findings (task-stop / pod-evict), Malware-for-Backup snapshot/AMI findings, and the Critical **Attack Sequence / Extended Threat Detection** correlated findings (novel multi-resource schema).

## Test plan
- [x] `python3 -m pytest -q` — 35 passed (32 baseline + 3 new: config integrity against the real config.json, and the KUBERNETES_API_CALL extraction path)
- [x] config.json validated: 134 entries, no duplicate types, every action is one the handler implements, excluded-unsafe types absent, original 51 entries preserved
- [x] `lambda_function.py` parses; Kubernetes field path confirmed against AWS API reference docs

https://claude.ai/code/session_0158xfJyVN5H28Pbrj2JWGag