### PR TITLE
fix: correctness & safety fixes for the GDPatrol remediation engine, deploy, and IAM

### DIFF
--- a/GDPatrol/config.json
+++ b/GDPatrol/config.json
@@ -65,7 +65,7 @@
       },
       {
         "type": "Persistence:IAMUser/NetworkPermissions",
-        "actions": "disable_sg_access",
+        "actions": ["disable_sg_access"],
         "reliability": 5
       },
       {

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -343,7 +343,7 @@ def delete_dynamodb_rule_entries(nacl_id: str, rule_numbers: set) -> None:
                 # Skip legacy/malformed items so one bad row doesn't abort the cleanup
                 try:
                     rule_number = int(item["rule_number"]["S"])
-                except KeyError, ValueError:
+                except (KeyError, ValueError):
                     continue
                 if rule_number in rule_numbers:
                     dynamodb_client.delete_item(

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -4,8 +4,8 @@ import logging
 import os
 import time
 import uuid
+import socket
 from inspect import stack
-from socket import gaierror, gethostbyname
 from typing import Any, Dict, List
 import requests
 import ipaddress
@@ -691,6 +691,24 @@ def asg_detach_instance(instance_id):
         return False
 
 
+def resolve_domain_a_records(domain: str, timeout: float = 5.0) -> List[str]:
+    """
+    Resolve all IPv4 (A record) addresses for a domain, bounded by a timeout so a
+    slow or hostile nameserver can't hang the invocation. Resolution errors are
+    swallowed, returning no addresses rather than raising.
+    """
+    previous_timeout = socket.getdefaulttimeout()
+    socket.setdefaulttimeout(timeout)
+    try:
+        results = socket.getaddrinfo(domain, None, socket.AF_INET)
+        return sorted({result[4][0] for result in results})
+    except OSError as e:
+        logger.error(f"GDPatrol: Error resolving domain {domain} - {e}")
+        return []
+    finally:
+        socket.setdefaulttimeout(previous_timeout)
+
+
 class Config:
     def __init__(self, finding_type: str) -> None:
         self.finding_type = finding_type
@@ -720,13 +738,13 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
             return
         logger.info(f"GDPatrol: Parsed Finding ID: {finding_id} - Finding Type: {finding_type}")
         config = Config(event["type"])
-        severity = int(event.get("severity", 0))
+        severity = float(event.get("severity", 0) or 0)
         count = event.get("service", {}).get("count", 0)
 
         config_actions = config.get_actions()
         config_reliability = config.get_reliability()
         resource_type = event.get("resource", {}).get("resourceType")
-    except KeyError as e:
+    except (KeyError, ValueError, TypeError, FileNotFoundError, json.JSONDecodeError) as e:
         logger.error(f"GDPatrol: Could not parse the Finding fields correctly, please verify that the JSON is correct. {e}")
         return
     instance_id = None
@@ -781,12 +799,11 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
             if severity + config_reliability > 10:
                 actions_to_be_executed += 1
                 logger.info(f"GDPatrol: Executing action {action}")
-                try:
-                    ip_address = gethostbyname(domain)
-                    result = blacklist_ip(ip_address)
-                    successful_actions += int(result)
-                except gaierror as e:
-                    logger.error(f"GDPatrol: Error resolving domain {domain} - {e}")
+                domain_blocked = False
+                for resolved_ip in resolve_domain_a_records(domain):
+                    if blacklist_ip(resolved_ip):
+                        domain_blocked = True
+                successful_actions += int(domain_blocked)
         elif action == "quarantine_instance":
             if severity + config_reliability > 10:
                 actions_to_be_executed += 1
@@ -839,8 +856,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
     logger.info(f"GDPatrol: Executed {successful_actions}/{actions_to_be_executed} actions successfully.")
 
     event_summary = summarize_event(event)
-    event_severity = event["severity"]
-    event_count = event["service"]["count"]
+    event_service = event.get("service", {})
+    event_severity = event.get("severity", 0)
+    event_count = event_service.get("count", "N/A")
 
     # Build concise Slack fields from the summary
     fields = [
@@ -848,8 +866,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
         {"title": "Account", "value": event_summary.get("account", "N/A"), "short": "true"},
         {"title": "Finding Type", "value": event_summary.get("finding_type", "N/A"), "short": "true"},
         {"title": "Severity", "value": str(event_severity), "short": "true"},
-        {"title": "First Seen", "value": event["service"]["eventFirstSeen"], "short": "true"},
-        {"title": "Last Seen", "value": event["service"]["eventLastSeen"], "short": "true"},
+        {"title": "First Seen", "value": event_service.get("eventFirstSeen", "N/A"), "short": "true"},
+        {"title": "Last Seen", "value": event_service.get("eventLastSeen", "N/A"), "short": "true"},
         {"title": "Count", "value": str(event_count), "short": "true"},
         {"title": "Action Type", "value": event_summary.get("action_type", "N/A"), "short": "true"},
     ]

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -489,11 +489,18 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
 
 
 def whitelist_ip(ip_address):
+    try:
+        ipaddress.ip_address(ip_address)
+    except ValueError:
+        logger.error(f"Invalid IP address: {ip_address}")
+        return False
+
     lock_acquired = False
     try:
         acquire_lock(GD_PATROL_LOCK_TABLE, GD_PATROL_NACL_LOCK_ID)
         lock_acquired = True
 
+        removed_count = 0
         paginator = ec2_client.get_paginator("describe_network_acls")
         for page in paginator.paginate():
             for nacl in page["NetworkAcls"]:
@@ -505,9 +512,14 @@ def whitelist_ip(ip_address):
                             Egress=rule["Egress"],
                             RuleNumber=rule["RuleNumber"],
                         )
+                        removed_count += 1
                         if not rule["Egress"]:
                             removed_rule_numbers.add(rule["RuleNumber"])
                 delete_dynamodb_rule_entries(nacl["NetworkAclId"], removed_rule_numbers)
+
+        if removed_count == 0:
+            logger.warning(f"GDPatrol: No matching rules found to whitelist {ip_address}")
+            return False
         logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {ip_address}")
         return True
 
@@ -544,8 +556,12 @@ def quarantine_instance(instance_id, vpc_id):
             ],
         )
 
-        # NOTE: Assign security group to instance
-        client.modify_instance_attribute(InstanceId=instance_id, Groups=[sg_id])
+        # NOTE: Assign the security group to every ENI — modify_instance_attribute only
+        # touches the primary interface, leaving other ENIs unisolated.
+        instance_described = client.describe_instances(InstanceIds=[instance_id])
+        network_interfaces = instance_described["Reservations"][0]["Instances"][0]["NetworkInterfaces"]
+        for eni in network_interfaces:
+            client.modify_network_interface_attribute(NetworkInterfaceId=eni["NetworkInterfaceId"], Groups=[sg_id])
 
         logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {instance_id}")
         return True
@@ -651,20 +667,23 @@ def enable_sg_access(username):
 
 
 def asg_detach_instance(instance_id):
+    if not instance_id:
+        logger.error(f"GDPatrol: {stack()[0][3]} called without an instance_id")
+        return False
     try:
         client = boto3.client("autoscaling")
         response = client.describe_auto_scaling_instances(InstanceIds=[instance_id], MaxRecords=1)
-        asg_name = None
         instances = response["AutoScalingInstances"]
-        if instances:
-            asg_name = instances[0]["AutoScalingGroupName"]
+        if not instances:
+            logger.warning(f"GDPatrol: {instance_id} is not a member of any Auto Scaling Group; nothing to detach")
+            return False
 
-        if asg_name is not None:
-            response = client.detach_instances(
-                InstanceIds=[instance_id],
-                AutoScalingGroupName=asg_name,
-                ShouldDecrementDesiredCapacity=False,
-            )
+        asg_name = instances[0]["AutoScalingGroupName"]
+        client.detach_instances(
+            InstanceIds=[instance_id],
+            AutoScalingGroupName=asg_name,
+            ShouldDecrementDesiredCapacity=False,
+        )
         logger.info(f"GDPatrol: Successfully executed action {stack()[0][3]} for {instance_id}")
         return True
     except Exception as e:

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -913,7 +913,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
             }
         ]
     }
-    if event_severity > 5:
+    if severity > 5:
         publish_message(slack_web_hook_url, json.dumps(guardduty_finding))
     logger.info(
         f"GDPatrol: Total actions: {total_config_actions} - Actions to be executed: {actions_to_be_executed} - Successful Actions: {successful_actions} - Finding ID:  {finding_id} - Finding Type: {finding_type}"

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -18,6 +18,9 @@ slack_web_hook_url = os.environ.get("SLACK_WEB_HOOK_URL")
 # Use environment variables for table names
 GD_PATROL_TABLE = os.environ.get("GD_PATROL_TABLE", "GDPatrol")
 GD_PATROL_LOCK_TABLE = os.environ.get("GD_PATROL_LOCK_TABLE", "GDPatrol_lock")
+# All NACL-mutating actions serialize on this single lock id, since blacklist_ip/whitelist_ip
+# each mutate every NACL in the account rather than just one keyed by IP.
+GD_PATROL_NACL_LOCK_ID = "gdpatrol-nacl"
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -218,7 +221,7 @@ def delete_oldest_acl_entry(nacl_id: str) -> None:
         # Do not raise here; just log the error and continue
 
 
-def acquire_lock(lock_table_name: str, lock_id: str, max_retries: int = 5, retry_delay: int = 2, ttl_seconds: int = 60) -> None:
+def acquire_lock(lock_table_name: str, lock_id: str, max_retries: int = 60, retry_delay: int = 3, ttl_seconds: int = 60) -> None:
     """
     Acquire a lock from a DynamoDB table. Adds a TTL to avoid deadlocks.
     """
@@ -301,8 +304,9 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
 
     # Use env table names if not provided
     lock_table_name = lock_table_name or GD_PATROL_LOCK_TABLE
-    # Make lock_id resource-specific
-    lock_id = lock_id or f"lock-{ip_address}"
+    # A single fixed lock id, since this function mutates every NACL in the account,
+    # not just resources related to ip_address.
+    lock_id = lock_id or GD_PATROL_NACL_LOCK_ID
     lock_acquired = False
     try:
         acquire_lock(lock_table_name, lock_id)
@@ -438,7 +442,11 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
 
 
 def whitelist_ip(ip_address):
+    lock_acquired = False
     try:
+        acquire_lock(GD_PATROL_LOCK_TABLE, GD_PATROL_NACL_LOCK_ID)
+        lock_acquired = True
+
         paginator = ec2_client.get_paginator("describe_network_acls")
         for page in paginator.paginate():
             for nacl in page["NetworkAcls"]:
@@ -459,6 +467,9 @@ def whitelist_ip(ip_address):
     except Exception as e:
         logger.error(f"GDPatrol: Error executing {stack()[0][3]} - {e}")
         return False
+    finally:
+        if lock_acquired:
+            release_lock(GD_PATROL_LOCK_TABLE, GD_PATROL_NACL_LOCK_ID)
 
 
 def quarantine_instance(instance_id, vpc_id):

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -425,9 +425,7 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                 except Exception as e:
                     logger.error(f"Error querying DynamoDB for NACL {nacl['NetworkAclId']} during cleanup: {e}")
                 # Newest first, so the 10 most recent are kept and the remainder (oldest) are deleted.
-                deny_rules_sorted = sorted(
-                    deny_rules, key=lambda r: created_at_by_rule_number.get(r["RuleNumber"], ""), reverse=True
-                )
+                deny_rules_sorted = sorted(deny_rules, key=lambda r: created_at_by_rule_number.get(r["RuleNumber"], ""), reverse=True)
                 # Keep only the 10 most recent rules
                 rules_to_delete = deny_rules_sorted[10:]
                 deleted_rule_numbers = set()

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -343,7 +343,9 @@ def delete_dynamodb_rule_entries(nacl_id: str, rule_numbers: set) -> None:
                 # Skip legacy/malformed items so one bad row doesn't abort the cleanup
                 try:
                     rule_number = int(item["rule_number"]["S"])
-                except (KeyError, ValueError):
+                # Keep the parenthesized tuple: ruff's py314 target would otherwise strip the
+                # parens to `except KeyError, ValueError:`, a SyntaxError on Python <3.14.
+                except (KeyError, ValueError):  # fmt: skip
                     continue
                 if rule_number in rule_numbers:
                     dynamodb_client.delete_item(

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -23,6 +23,12 @@ GD_PATROL_LOCK_TABLE = os.environ.get("GD_PATROL_LOCK_TABLE", "GDPatrol_lock")
 # each mutate every NACL in the account rather than just one keyed by IP.
 GD_PATROL_NACL_LOCK_ID = "gdpatrol-nacl"
 
+# Max ingress deny rules GDPatrol maintains per NACL. AWS default is 20 rules/direction,
+# raisable to 40 via the "Rules per network ACL" (L-2AEEBF1A) Service Quota. Set
+# GD_PATROL_NACL_RULE_LIMIT to match the account's actual quota so GDPatrol uses the
+# available headroom instead of self-capping at 20.
+NACL_RULE_LIMIT = int(os.environ.get("GD_PATROL_NACL_RULE_LIMIT", "20"))
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -413,8 +419,8 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                 if not rule["Egress"] and rule["RuleAction"] == "deny" and rule.get("CidrBlock", "").endswith("/32")
             ]
 
-            # Check if we're approaching the limit (max 20 rules per direction)
-            if len(deny_rules) >= 19:
+            # Check if we're approaching the per-direction rule limit
+            if len(deny_rules) >= NACL_RULE_LIMIT - 1:
                 logger.warning(f"NACL {nacl['NetworkAclId']} has {len(deny_rules)} deny rules, performing aggressive cleanup.")
                 # Rule numbers no longer indicate age once the allocator falls back to the high end,
                 # so order by the DynamoDB created_at tracking data instead. Rules with no tracking
@@ -432,10 +438,10 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                         created_at_by_rule_number[int(item["rule_number"]["S"])] = item["created_at"]["S"]
                 except Exception as e:
                     logger.error(f"Error querying DynamoDB for NACL {nacl['NetworkAclId']} during cleanup: {e}")
-                # Newest first, so the 10 most recent are kept and the remainder (oldest) are deleted.
+                # Newest first, so the most recent half is kept and the remainder (oldest) deleted.
                 deny_rules_sorted = sorted(deny_rules, key=lambda r: created_at_by_rule_number.get(r["RuleNumber"], ""), reverse=True)
-                # Keep only the 10 most recent rules
-                rules_to_delete = deny_rules_sorted[10:]
+                # Keep the most recent half of the limit; evict the rest to make headroom.
+                rules_to_delete = deny_rules_sorted[max(1, NACL_RULE_LIMIT // 2) :]
                 deleted_rule_numbers = set()
                 for rule in rules_to_delete:
                     try:

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -395,15 +395,40 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                 blocked_count += 1
                 continue
 
-            # Get all deny rules for this NACL
-            deny_rules = [rule for rule in nacl["Entries"] if not rule["Egress"] and rule["RuleAction"] == "deny"]
+            # Get all deny rules for this NACL. Only GDPatrol-managed rules (ingress deny with a
+            # /32 CidrBlock) count toward the threshold and are eligible for cleanup — this must
+            # never sweep up a customer's own deny rule (e.g. a subnet-level block, or the implicit
+            # default-deny at 32767). Same predicate as delete_oldest_acl_entry's fallback.
+            deny_rules = [
+                rule
+                for rule in nacl["Entries"]
+                if not rule["Egress"] and rule["RuleAction"] == "deny" and rule.get("CidrBlock", "").endswith("/32")
+            ]
 
             # Check if we're approaching the limit (max 20 rules per direction)
             if len(deny_rules) >= 19:
                 logger.warning(f"NACL {nacl['NetworkAclId']} has {len(deny_rules)} deny rules, performing aggressive cleanup.")
-                # New rules get decreasing numbers (min - 1), so the lowest rule numbers are the most recent
-                deny_rules_sorted = sorted(deny_rules, key=lambda r: r["RuleNumber"])
-                # Keep only the 10 most recent (lowest) rule numbers
+                # Rule numbers no longer indicate age once the allocator falls back to the high end,
+                # so order by the DynamoDB created_at tracking data instead. Rules with no tracking
+                # row have drifted from DynamoDB; treat them as oldest (safe to evict first) via the
+                # "" sentinel, which sorts before any real timestamp string.
+                created_at_by_rule_number: Dict[int, str] = {}
+                try:
+                    tracking = dynamodb_client.query(
+                        TableName=GD_PATROL_TABLE,
+                        KeyConditionExpression="#pk = :pk_value",
+                        ExpressionAttributeNames={"#pk": "network_acl_id"},
+                        ExpressionAttributeValues={":pk_value": {"S": nacl["NetworkAclId"]}},
+                    )
+                    for item in tracking.get("Items", []):
+                        created_at_by_rule_number[int(item["rule_number"]["S"])] = item["created_at"]["S"]
+                except Exception as e:
+                    logger.error(f"Error querying DynamoDB for NACL {nacl['NetworkAclId']} during cleanup: {e}")
+                # Newest first, so the 10 most recent are kept and the remainder (oldest) are deleted.
+                deny_rules_sorted = sorted(
+                    deny_rules, key=lambda r: created_at_by_rule_number.get(r["RuleNumber"], ""), reverse=True
+                )
+                # Keep only the 10 most recent rules
                 rules_to_delete = deny_rules_sorted[10:]
                 deleted_rule_numbers = set()
                 for rule in rules_to_delete:

--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -11,6 +11,7 @@ import requests
 import ipaddress
 
 import boto3
+from botocore.exceptions import ClientError
 
 # Use uppercase for environment variable
 slack_web_hook_url = os.environ.get("SLACK_WEB_HOOK_URL")
@@ -166,6 +167,54 @@ def create_network_acl_entry(ip_address: str, nacl_id: str, rule_number: int) ->
         raise
 
 
+def _next_free_ingress_deny_rule_number(entries: List[Dict[str, Any]]) -> int | None:
+    """
+    Return an unused ingress rule number for a new ingress deny rule, or None if the NACL
+    has no free ingress rule numbers left.
+
+    Considers ALL ingress entries (allow and deny) so the result never collides with a
+    pre-existing rule — ingress and egress rule numbers are independent namespaces, so
+    egress entries are ignored.
+
+    Preference order: one below the current lowest GDPatrol deny rule (the existing
+    decrement scheme), or the next free number below that. If the low end (near 1) is
+    exhausted, search downward from the high end (32766; 32767 is the implicit default-deny)
+    instead of evicting whoever holds a fixed slot.
+    """
+    used = {entry["RuleNumber"] for entry in entries if not entry["Egress"]}
+    deny_numbers = [entry["RuleNumber"] for entry in entries if not entry["Egress"] and entry["RuleAction"] == "deny"]
+    start = (min(deny_numbers) - 1) if deny_numbers else 100
+
+    candidate = start
+    while candidate >= 1:
+        if candidate not in used:
+            return candidate
+        candidate -= 1
+
+    # Low end exhausted (or fully occupied); search down from the high end instead.
+    candidate = 32766
+    floor = max(start, 0)
+    while candidate > floor:
+        if candidate not in used:
+            return candidate
+        candidate -= 1
+
+    return None
+
+
+def _create_and_track_deny_rule(ip_address: str, nacl_id: str, rule_number: int) -> None:
+    """Create the deny rule in AWS and record it in DynamoDB so it can be found again as "oldest"."""
+    create_network_acl_entry(ip_address, nacl_id, rule_number)
+    dynamodb_client.put_item(
+        TableName=GD_PATROL_TABLE,
+        Item={
+            "network_acl_id": {"S": nacl_id},
+            "created_at": {"S": str(time.time())},
+            "rule_number": {"S": str(rule_number)},
+        },
+    )
+
+
 def delete_oldest_acl_entry(nacl_id: str) -> None:
     """
     Delete the oldest ACL entry for a given Network ACL ID.
@@ -182,13 +231,18 @@ def delete_oldest_acl_entry(nacl_id: str) -> None:
         if not items:
             logger.warning(f"No entries found in DynamoDB for NACL {nacl_id}. Falling back to AWS NACL entries.")
             nacl = ec2_client.describe_network_acls(NetworkAclIds=[nacl_id])["NetworkAcls"][0]
-            # Only consider deny, ingress rules (Egress=False, RuleAction='deny')
-            deny_rules = [rule for rule in nacl["Entries"] if not rule["Egress"] and rule["RuleAction"] == "deny"]
+            # Only consider GDPatrol-managed rules: ingress deny rules with a /32 CidrBlock.
+            # This excludes the implicit default-deny (0.0.0.0/0 @ 32767) and customer subnet-level denies.
+            deny_rules = [
+                rule
+                for rule in nacl["Entries"]
+                if not rule["Egress"] and rule["RuleAction"] == "deny" and rule.get("CidrBlock", "").endswith("/32")
+            ]
             if not deny_rules:
-                logger.warning(f"No deny ingress rules found in NACL {nacl_id}. Nothing to delete.")
+                logger.warning(f"No GDPatrol-managed deny ingress rules found in NACL {nacl_id}. Nothing to delete.")
                 return
-            # Find the oldest by lowest rule number
-            oldest_rule = min(deny_rules, key=lambda r: r["RuleNumber"])
+            # New rules get decreasing numbers, so the HIGHEST rule number is the oldest.
+            oldest_rule = max(deny_rules, key=lambda r: r["RuleNumber"])
             logger.info(f"Deleting fallback network_acl rule_number = {oldest_rule['RuleNumber']} for {nacl_id}")
             ec2_client.delete_network_acl_entry(
                 Egress=False,
@@ -201,12 +255,19 @@ def delete_oldest_acl_entry(nacl_id: str) -> None:
         oldest_item = items[0]
         logger.info(f"Deleting network_acl rule_number = {oldest_item['rule_number']['S']} for {nacl_id}")
 
-        ec2_client.delete_network_acl_entry(
-            Egress=False,
-            DryRun=os.environ.get("DELETE_NACL_ENTRY_DRY_RUN", "False").lower() == "true",
-            NetworkAclId=nacl_id,
-            RuleNumber=int(oldest_item["rule_number"]["S"]),
-        )
+        try:
+            ec2_client.delete_network_acl_entry(
+                Egress=False,
+                DryRun=os.environ.get("DELETE_NACL_ENTRY_DRY_RUN", "False").lower() == "true",
+                NetworkAclId=nacl_id,
+                RuleNumber=int(oldest_item["rule_number"]["S"]),
+            )
+        except ClientError as error:
+            if error.response.get("Error", {}).get("Code") != "InvalidNetworkAclEntry.NotFound":
+                raise
+            # AWS and DynamoDB have drifted apart; reconcile by removing the stale tracking row below,
+            # instead of leaving it to be returned as "oldest" forever.
+            logger.warning(f"Rule {oldest_item['rule_number']['S']} not found in NACL {nacl_id}; reconciling stale DynamoDB row.")
 
         dynamodb_client.delete_item(
             TableName=GD_PATROL_TABLE,
@@ -358,46 +419,18 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                         logger.error(f"Failed to delete deny rule {rule['RuleNumber']}: {e}")
                 delete_dynamodb_rule_entries(nacl["NetworkAclId"], deleted_rule_numbers)
 
-            if not deny_rules:
-                # If no deny rules exist, start with rule number 100
-                target_rule_number = 100
-            else:
-                # Find the minimum rule number among deny rules
-                min_rule_id = min(rule["RuleNumber"] for rule in deny_rules)
-                # If we hit the lower bound, wrap around to a high rule number (e.g., 32700)
-                if min_rule_id <= 2:
-                    logger.warning(f"Rule number {min_rule_id} is too low; wrapping to 32700 for NACL {nacl['NetworkAclId']}")
-                    target_rule_number = 32700
-                    # Delete any existing rule at 32700 before creating
-                    for rule in nacl["Entries"]:
-                        if not rule["Egress"] and rule["RuleAction"] == "deny" and rule["RuleNumber"] == 32700:
-                            try:
-                                ec2_client.delete_network_acl_entry(
-                                    Egress=False,
-                                    NetworkAclId=nacl["NetworkAclId"],
-                                    RuleNumber=32700,
-                                )
-                                delete_dynamodb_rule_entries(nacl["NetworkAclId"], {32700})
-                                logger.info(f"Deleted existing deny rule 32700 in NACL {nacl['NetworkAclId']}")
-                            except Exception as e:
-                                logger.error(f"Failed to delete existing rule 32700: {e}")
-                    # (Do not continue; proceed to create the new rule at 32700)
-                else:
-                    target_rule_number = min_rule_id - 1
+            target_rule_number = _next_free_ingress_deny_rule_number(nacl["Entries"])
+            if target_rule_number is None:
+                logger.warning(f"No free ingress rule numbers in NACL {nacl['NetworkAclId']}; deleting oldest entry to make room")
+                delete_oldest_acl_entry(nacl["NetworkAclId"])
+                refreshed = ec2_client.describe_network_acls(NetworkAclIds=[nacl["NetworkAclId"]])["NetworkAcls"][0]
+                target_rule_number = _next_free_ingress_deny_rule_number(refreshed["Entries"])
+                if target_rule_number is None:
+                    logger.error(f"NACL {nacl['NetworkAclId']} still has no free ingress rule numbers after cleanup; skipping")
+                    continue
 
             try:
-                create_network_acl_entry(ip_address, nacl["NetworkAclId"], target_rule_number)
-
-                # Store the new entry in DynamoDB
-                dynamodb_client.put_item(
-                    TableName=GD_PATROL_TABLE,
-                    Item={
-                        "network_acl_id": {"S": nacl["NetworkAclId"]},
-                        "created_at": {"S": str(time.time())},
-                        "rule_number": {"S": str(target_rule_number)},
-                    },
-                )
-
+                _create_and_track_deny_rule(ip_address, nacl["NetworkAclId"], target_rule_number)
                 logger.info(f"Blacklisted IP {ip_address} in NACL {nacl['NetworkAclId']}")
                 blocked_count += 1
 
@@ -408,21 +441,35 @@ def blacklist_ip(ip_address: str, lock_table_name: str = None, lock_id: str = No
                         logger.info(f"Network ACL limit exceeded for {nacl['NetworkAclId']}, attempting to delete oldest entry")
                         delete_oldest_acl_entry(nacl["NetworkAclId"])
                         # Retry creating the entry after deleting the oldest one
-                        create_network_acl_entry(ip_address, nacl["NetworkAclId"], target_rule_number)
-                        # Store the new entry in DynamoDB
-                        dynamodb_client.put_item(
-                            TableName=GD_PATROL_TABLE,
-                            Item={
-                                "network_acl_id": {"S": nacl["NetworkAclId"]},
-                                "created_at": {"S": str(time.time())},
-                                "rule_number": {"S": str(target_rule_number)},
-                            },
-                        )
+                        _create_and_track_deny_rule(ip_address, nacl["NetworkAclId"], target_rule_number)
                         logger.info(f"Blacklisted IP {ip_address} in NACL {nacl['NetworkAclId']} after deleting oldest entry")
                         blocked_count += 1
                     except Exception as retry_error:
                         logger.error(f"Failed to create entry after deleting oldest: {retry_error}")
                         # Try the next NACL
+                        continue
+                elif "NetworkAclEntryAlreadyExists" in str(error):
+                    # Our snapshot of the NACL was stale (a concurrent mutation took this number);
+                    # retry with a freshly-computed free number instead of failing outright.
+                    logger.warning(f"Rule number {target_rule_number} already exists in {nacl['NetworkAclId']}; retrying with another")
+                    retried_successfully = False
+                    for _ in range(3):
+                        refreshed = ec2_client.describe_network_acls(NetworkAclIds=[nacl["NetworkAclId"]])["NetworkAcls"][0]
+                        retry_rule_number = _next_free_ingress_deny_rule_number(refreshed["Entries"])
+                        if retry_rule_number is None:
+                            break
+                        try:
+                            _create_and_track_deny_rule(ip_address, nacl["NetworkAclId"], retry_rule_number)
+                            logger.info(f"Blacklisted IP {ip_address} in NACL {nacl['NetworkAclId']} at retried rule {retry_rule_number}")
+                            blocked_count += 1
+                            retried_successfully = True
+                            break
+                        except Exception as retry_error:
+                            if "NetworkAclEntryAlreadyExists" not in str(retry_error):
+                                logger.error(f"Failed to create entry at retried rule number: {retry_error}")
+                                break
+                    if not retried_successfully:
+                        logger.error(f"Could not blacklist {ip_address} in NACL {nacl['NetworkAclId']}: no free rule number available")
                         continue
                 else:
                     logger.error(f"Error creating network_acl entry: {error}")

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To enable Slack notifications, set the `SLACK_WEB_HOOK_URL` environment variable
 `GDPatrol` Lambda function (via the AWS Console or CLI) after running `deploy.py` — the deploy script
 does not set this automatically.
 
-The deployment script deploys to all enabled regions in parallel (5 at a time) and requires the following permissions:
+The deployment script deploys to all enabled regions sequentially and requires the following permissions:
 ```
 IAM:
 List Roles, Delete Role Policy, Delete Role, Create Role, Put Role Policy

--- a/deploy.py
+++ b/deploy.py
@@ -90,6 +90,11 @@ def run(slack_web_hook_url=None):
     # Pass the Slack webhook through to the function; without it the Lambda
     # logs "Error publishing message to Slack" and no notification is sent
     lambda_env = {"DELETE_NACL_ENTRY_DRY_RUN": "False"}
+    # Match the account's actual "Rules per network ACL" quota (default 20, raisable to 40)
+    # so GDPatrol uses the available headroom instead of self-capping at 20.
+    nacl_rule_limit = environ.get("GD_PATROL_NACL_RULE_LIMIT")
+    if nacl_rule_limit:
+        lambda_env["GD_PATROL_NACL_RULE_LIMIT"] = nacl_rule_limit
     slack_web_hook_url = slack_web_hook_url or environ.get("SLACK_WEB_HOOK_URL")
     if slack_web_hook_url:
         lambda_env["SLACK_WEB_HOOK_URL"] = slack_web_hook_url

--- a/deploy.py
+++ b/deploy.py
@@ -3,7 +3,6 @@ import subprocess
 import tempfile
 from os import environ, remove
 from pathlib import Path
-from random import randrange
 from shutil import copy2, copytree, make_archive, rmtree
 from time import sleep
 import boto3
@@ -165,15 +164,19 @@ def run(slack_web_hook_url=None):
             Targets=[{"Id": target_id, "Arn": target_arn, "InputPath": "$.detail"}],
         )
 
-        # We are adding the trigger to the Lambda function so that it will be invoked every time  a finding is sent over
-        statement_id = str(randrange(10**11, 10**12))
-        lmb.add_permission(
-            FunctionName=lambda_response["FunctionName"],
-            StatementId=statement_id,
-            Action="lambda:InvokeFunction",
-            Principal="events.amazonaws.com",
-            SourceArn=created_rule["RuleArn"],
-        )
+        # Stable StatementId so redeploys don't accumulate duplicate resource-policy
+        # statements toward Lambda's policy-size limit.
+        try:
+            lmb.add_permission(
+                FunctionName=lambda_response["FunctionName"],
+                StatementId="GDPatrolEventBridgeInvoke",
+                Action="lambda:InvokeFunction",
+                Principal="events.amazonaws.com",
+                SourceArn=created_rule["RuleArn"],
+            )
+        except lmb.exceptions.ResourceConflictException:
+            # Permission already present from a prior deploy — idempotent.
+            pass
         print("Successfully deployed the GDPatrol lambda function in region {}.".format(str(region)))
 
         # Create DynamoDB table if not existed

--- a/deploy.py
+++ b/deploy.py
@@ -101,152 +101,170 @@ def run(slack_web_hook_url=None):
     else:
         print("WARNING: SLACK_WEB_HOOK_URL is not set; Slack notifications will fail.")
 
+    deployed_regions = []
+    failed_regions = []
     for region in regions:
-        lmb = boto3.client("lambda", region_name=region)
-        cw_events = boto3.client("events", region_name=region)
-        gd = boto3.client("guardduty", region_name=region)
-        detector_ids = gd.list_detectors()["DetectorIds"]
-        if not detector_ids:
-            created_detector = gd.create_detector(Enable=True)
-            print("Created GuardDuty detector: {}".format(created_detector["DetectorId"]))
-        else:
-            det_id = detector_ids[0]
-            # Only re-enable if it is actually disabled, and tolerate member/delegated-admin
-            # accounts where the member cannot manage detector enablement (the GuardDuty
-            # administrator account owns it) — update_detector raises BadRequestException there.
-            try:
-                if gd.get_detector(DetectorId=det_id).get("Status") != "ENABLED":
-                    gd.update_detector(DetectorId=det_id, Enable=True)
-                    print("Re-enabled GuardDuty detector: {}".format(det_id))
-                else:
-                    print("Detector already enabled: {}".format(det_id))
-            except Exception as e:
-                print("Could not manage detector {} (enablement may be org-managed): {}".format(det_id, e))
+        # Isolate each region's deploy: a single region raising (a member-account
+        # detector error, a mid-run file deletion, etc.) must not abort the rest
+        # of the rollout.
+        try:
+            lmb = boto3.client("lambda", region_name=region)
+            cw_events = boto3.client("events", region_name=region)
+            gd = boto3.client("guardduty", region_name=region)
+            detector_ids = gd.list_detectors()["DetectorIds"]
+            if not detector_ids:
+                created_detector = gd.create_detector(Enable=True)
+                print("Created GuardDuty detector: {}".format(created_detector["DetectorId"]))
+            else:
+                det_id = detector_ids[0]
+                # Only re-enable if it is actually disabled, and tolerate member/delegated-admin
+                # accounts where the member cannot manage detector enablement (the GuardDuty
+                # administrator account owns it) — update_detector raises BadRequestException there.
+                try:
+                    if gd.get_detector(DetectorId=det_id).get("Status") != "ENABLED":
+                        gd.update_detector(DetectorId=det_id, Enable=True)
+                        print("Re-enabled GuardDuty detector: {}".format(det_id))
+                    else:
+                        print("Detector already enabled: {}".format(det_id))
+                except Exception as e:
+                    print("Could not manage detector {} (enablement may be org-managed): {}".format(det_id, e))
 
-        sleep(7)  # Lambda bug: create function right after the role is created will cause AccessDeniedExceptionKMS error
-        # A freshly created IAM role can take a while to propagate, and
-        # create_function intermittently fails with "The role defined for the
-        # function cannot be assumed by Lambda" until it does — retry with backoff.
-        for attempt in range(5):
+            sleep(7)  # Lambda bug: create function right after the role is created will cause AccessDeniedExceptionKMS error
+            # A freshly created IAM role can take a while to propagate, and
+            # create_function intermittently fails with "The role defined for the
+            # function cannot be assumed by Lambda" until it does — retry with backoff.
+            for attempt in range(5):
+                try:
+                    lambda_response = lmb.create_function(
+                        FunctionName="GDPatrol",
+                        Runtime=LAMBDA_RUNTIME,
+                        Role=lambda_role_arn,
+                        Handler="lambda_function.lambda_handler",
+                        Code={"ZipFile": open(zipped, "rb").read()},
+                        Timeout=300,
+                        MemorySize=128,
+                        Environment={"Variables": lambda_env},
+                    )
+                    break
+                except lmb.exceptions.ResourceConflictException:
+                    # The function already exists (e.g. a redeploy) — update it in place
+                    # instead of failing, so a stale function never blocks the deploy.
+                    lambda_response = lmb.update_function_code(
+                        FunctionName="GDPatrol",
+                        ZipFile=open(zipped, "rb").read(),
+                    )
+                    # update_function_code leaves the function InProgress for a few
+                    # seconds; update_function_configuration raises ResourceConflict
+                    # if called before it settles.
+                    lmb.get_waiter("function_updated").wait(FunctionName="GDPatrol")
+                    lmb.update_function_configuration(
+                        FunctionName="GDPatrol",
+                        Runtime=LAMBDA_RUNTIME,
+                        Role=lambda_role_arn,
+                        Handler="lambda_function.lambda_handler",
+                        Timeout=300,
+                        MemorySize=128,
+                        Environment={"Variables": lambda_env},
+                    )
+                    break
+                except lmb.exceptions.InvalidParameterValueException as e:
+                    if "cannot be assumed" not in str(e) or attempt == 4:
+                        raise
+                    print("Role not yet assumable in region {}, retrying...".format(str(region)))
+                    sleep(10)
+            target_arn = lambda_response["FunctionArn"]
+            # Stable target Id so put_targets replaces the same target on each redeploy
+            # instead of accumulating toward EventBridge's hard limit of 5 targets/rule.
+            target_id = "GDPatrolTarget"
+
+            created_rule = cw_events.put_rule(
+                Name="GDPatrol",
+                EventPattern='{"source":["aws.guardduty"],"detail-type":["GuardDuty Finding"]}',
+            )
+            cw_events.put_targets(
+                Rule="GDPatrol",
+                Targets=[{"Id": target_id, "Arn": target_arn, "InputPath": "$.detail"}],
+            )
+
+            # Stable StatementId so redeploys don't accumulate duplicate resource-policy
+            # statements toward Lambda's policy-size limit.
             try:
-                lambda_response = lmb.create_function(
-                    FunctionName="GDPatrol",
-                    Runtime=LAMBDA_RUNTIME,
-                    Role=lambda_role_arn,
-                    Handler="lambda_function.lambda_handler",
-                    Code={"ZipFile": open(zipped, "rb").read()},
-                    Timeout=300,
-                    MemorySize=128,
-                    Environment={"Variables": lambda_env},
+                lmb.add_permission(
+                    FunctionName=lambda_response["FunctionName"],
+                    StatementId="GDPatrolEventBridgeInvoke",
+                    Action="lambda:InvokeFunction",
+                    Principal="events.amazonaws.com",
+                    SourceArn=created_rule["RuleArn"],
                 )
-                break
             except lmb.exceptions.ResourceConflictException:
-                # The function already exists (e.g. a redeploy) — update it in place
-                # instead of failing, so a stale function never blocks the deploy.
-                lambda_response = lmb.update_function_code(
-                    FunctionName="GDPatrol",
-                    ZipFile=open(zipped, "rb").read(),
+                # Permission already present from a prior deploy — idempotent.
+                pass
+            print("Successfully deployed the GDPatrol lambda function in region {}.".format(str(region)))
+
+            # Create DynamoDB table if not existed
+            dynamodb_client = boto3.client("dynamodb", region_name=region)
+            try:
+                response = dynamodb_client.create_table(
+                    AttributeDefinitions=[
+                        {
+                            "AttributeName": "network_acl_id",
+                            "AttributeType": "S",
+                        },
+                        {
+                            "AttributeName": "created_at",
+                            "AttributeType": "S",
+                        },
+                    ],
+                    KeySchema=[
+                        {
+                            "AttributeName": "network_acl_id",
+                            "KeyType": "HASH",
+                        },
+                        {
+                            "AttributeName": "created_at",
+                            "KeyType": "RANGE",
+                        },
+                    ],
+                    BillingMode="PAY_PER_REQUEST",
+                    TableName="GDPatrol",
                 )
-                # update_function_code leaves the function InProgress for a few
-                # seconds; update_function_configuration raises ResourceConflict
-                # if called before it settles.
-                lmb.get_waiter("function_updated").wait(FunctionName="GDPatrol")
-                lmb.update_function_configuration(
-                    FunctionName="GDPatrol",
-                    Runtime=LAMBDA_RUNTIME,
-                    Role=lambda_role_arn,
-                    Handler="lambda_function.lambda_handler",
-                    Timeout=300,
-                    MemorySize=128,
-                    Environment={"Variables": lambda_env},
+            except dynamodb_client.exceptions.ResourceInUseException:
+                pass
+
+            # Create the lock table used by blacklist_ip's acquire_lock/release_lock
+            try:
+                response = dynamodb_client.create_table(
+                    AttributeDefinitions=[
+                        {
+                            "AttributeName": "lock_id",
+                            "AttributeType": "S",
+                        },
+                    ],
+                    KeySchema=[
+                        {
+                            "AttributeName": "lock_id",
+                            "KeyType": "HASH",
+                        },
+                    ],
+                    BillingMode="PAY_PER_REQUEST",
+                    TableName="GDPatrol_lock",
                 )
-                break
-            except lmb.exceptions.InvalidParameterValueException as e:
-                if "cannot be assumed" not in str(e) or attempt == 4:
-                    raise
-                print("Role not yet assumable in region {}, retrying...".format(str(region)))
-                sleep(10)
-        target_arn = lambda_response["FunctionArn"]
-        # Stable target Id so put_targets replaces the same target on each redeploy
-        # instead of accumulating toward EventBridge's hard limit of 5 targets/rule.
-        target_id = "GDPatrolTarget"
+            except dynamodb_client.exceptions.ResourceInUseException:
+                pass
 
-        created_rule = cw_events.put_rule(
-            Name="GDPatrol",
-            EventPattern='{"source":["aws.guardduty"],"detail-type":["GuardDuty Finding"]}',
-        )
-        cw_events.put_targets(
-            Rule="GDPatrol",
-            Targets=[{"Id": target_id, "Arn": target_arn, "InputPath": "$.detail"}],
-        )
-
-        # Stable StatementId so redeploys don't accumulate duplicate resource-policy
-        # statements toward Lambda's policy-size limit.
-        try:
-            lmb.add_permission(
-                FunctionName=lambda_response["FunctionName"],
-                StatementId="GDPatrolEventBridgeInvoke",
-                Action="lambda:InvokeFunction",
-                Principal="events.amazonaws.com",
-                SourceArn=created_rule["RuleArn"],
-            )
-        except lmb.exceptions.ResourceConflictException:
-            # Permission already present from a prior deploy — idempotent.
-            pass
-        print("Successfully deployed the GDPatrol lambda function in region {}.".format(str(region)))
-
-        # Create DynamoDB table if not existed
-        dynamodb_client = boto3.client("dynamodb", region_name=region)
-        try:
-            response = dynamodb_client.create_table(
-                AttributeDefinitions=[
-                    {
-                        "AttributeName": "network_acl_id",
-                        "AttributeType": "S",
-                    },
-                    {
-                        "AttributeName": "created_at",
-                        "AttributeType": "S",
-                    },
-                ],
-                KeySchema=[
-                    {
-                        "AttributeName": "network_acl_id",
-                        "KeyType": "HASH",
-                    },
-                    {
-                        "AttributeName": "created_at",
-                        "KeyType": "RANGE",
-                    },
-                ],
-                BillingMode="PAY_PER_REQUEST",
-                TableName="GDPatrol",
-            )
-        except dynamodb_client.exceptions.ResourceInUseException:
-            pass
-
-        # Create the lock table used by blacklist_ip's acquire_lock/release_lock
-        try:
-            response = dynamodb_client.create_table(
-                AttributeDefinitions=[
-                    {
-                        "AttributeName": "lock_id",
-                        "AttributeType": "S",
-                    },
-                ],
-                KeySchema=[
-                    {
-                        "AttributeName": "lock_id",
-                        "KeyType": "HASH",
-                    },
-                ],
-                BillingMode="PAY_PER_REQUEST",
-                TableName="GDPatrol_lock",
-            )
-        except dynamodb_client.exceptions.ResourceInUseException:
-            pass
+            deployed_regions.append(region)
+        except Exception as e:
+            print("Failed to deploy region {}: {}".format(region, e))
+            failed_regions.append(region)
+            continue
 
     remove(zipped)
+
+    print("Deploy summary: {} succeeded, {} failed.".format(len(deployed_regions), len(failed_regions)))
+    if deployed_regions:
+        print("  Succeeded: {}".format(", ".join(deployed_regions)))
+    if failed_regions:
+        print("  Failed: {}".format(", ".join(failed_regions)))
 
 
 if __name__ == "__main__":

--- a/deploy.py
+++ b/deploy.py
@@ -74,6 +74,9 @@ def run(slack_web_hook_url=None):
         for role in response["Roles"]:
             if role["RoleName"] == "GDPatrolRole":
                 lambda_role_arn = role["Arn"]
+                break
+        if lambda_role_arn is not None:
+            break
 
     if lambda_role_arn is None:
         created_role = iam.create_role(RoleName="GDPatrolRole", AssumeRolePolicyDocument=assume_role_policy)
@@ -129,6 +132,10 @@ def run(slack_web_hook_url=None):
                     FunctionName="GDPatrol",
                     ZipFile=open(zipped, "rb").read(),
                 )
+                # update_function_code leaves the function InProgress for a few
+                # seconds; update_function_configuration raises ResourceConflict
+                # if called before it settles.
+                lmb.get_waiter("function_updated").wait(FunctionName="GDPatrol")
                 lmb.update_function_configuration(
                     FunctionName="GDPatrol",
                     Runtime=LAMBDA_RUNTIME,
@@ -145,7 +152,9 @@ def run(slack_web_hook_url=None):
                 print("Role not yet assumable in region {}, retrying...".format(str(region)))
                 sleep(10)
         target_arn = lambda_response["FunctionArn"]
-        target_id = "Id" + str(randrange(10**11, 10**12))
+        # Stable target Id so put_targets replaces the same target on each redeploy
+        # instead of accumulating toward EventBridge's hard limit of 5 targets/rule.
+        target_id = "GDPatrolTarget"
 
         created_rule = cw_events.put_rule(
             Name="GDPatrol",

--- a/deploy.py
+++ b/deploy.py
@@ -66,17 +66,18 @@ def run(slack_web_hook_url=None):
         lambda_policy = lp.read()
 
     iam = boto3.client("iam")
-    # delete the role if it already exists, so it can be deployed with
-    # the latest configuration
-
+    # get-or-create the role so already-deployed Lambdas in other regions that
+    # reference it keep working during redeploy; put_role_policy is idempotent,
+    # so it's safe to call whether the role is new or already existed.
+    lambda_role_arn = None
     for response in iam.get_paginator("list_roles").paginate():
         for role in response["Roles"]:
             if role["RoleName"] == "GDPatrolRole":
-                iam.delete_role_policy(RoleName="GDPatrolRole", PolicyName="GDPatrol_lambda_policy")
-                iam.delete_role(RoleName="GDPatrolRole")
+                lambda_role_arn = role["Arn"]
 
-    created_role = iam.create_role(RoleName="GDPatrolRole", AssumeRolePolicyDocument=assume_role_policy)
-    lambda_role_arn = created_role["Role"]["Arn"]
+    if lambda_role_arn is None:
+        created_role = iam.create_role(RoleName="GDPatrolRole", AssumeRolePolicyDocument=assume_role_policy)
+        lambda_role_arn = created_role["Role"]["Arn"]
 
     iam.put_role_policy(
         RoleName="GDPatrolRole",
@@ -101,18 +102,11 @@ def run(slack_web_hook_url=None):
             created_detector = gd.create_detector(Enable=True)
             print("Created GuardDuty detector: {}".format(created_detector["DetectorId"]))
         else:
-            # gd.update_detector(
-            #     DetectorId=gd.list_detectors()["DetectorIds"][0], Enable=True
-            # )
+            gd.update_detector(DetectorId=gd.list_detectors()["DetectorIds"][0], Enable=True)
             print("Detector already exists: {}".format(gd.list_detectors()["DetectorIds"][0]))
 
-        try:
-            lmb.get_function(FunctionName="GDPatrol")
-            lmb.delete_function(FunctionName="GDPatrol")
-        except Exception:
-            pass
-        sleep(7)  # Lambda bug: create function right after the role deleted will cause AccessDeniedExceptionKMS error
-        # A freshly recreated IAM role can take a while to propagate, and
+        sleep(7)  # Lambda bug: create function right after the role is created will cause AccessDeniedExceptionKMS error
+        # A freshly created IAM role can take a while to propagate, and
         # create_function intermittently fails with "The role defined for the
         # function cannot be assumed by Lambda" until it does — retry with backoff.
         for attempt in range(5):
@@ -128,6 +122,23 @@ def run(slack_web_hook_url=None):
                     Environment={"Variables": lambda_env},
                 )
                 break
+            except lmb.exceptions.ResourceConflictException:
+                # The function already exists (e.g. a redeploy) — update it in place
+                # instead of failing, so a stale function never blocks the deploy.
+                lambda_response = lmb.update_function_code(
+                    FunctionName="GDPatrol",
+                    ZipFile=open(zipped, "rb").read(),
+                )
+                lmb.update_function_configuration(
+                    FunctionName="GDPatrol",
+                    Runtime=LAMBDA_RUNTIME,
+                    Role=lambda_role_arn,
+                    Handler="lambda_function.lambda_handler",
+                    Timeout=300,
+                    MemorySize=128,
+                    Environment={"Variables": lambda_env},
+                )
+                break
             except lmb.exceptions.InvalidParameterValueException as e:
                 if "cannot be assumed" not in str(e) or attempt == 4:
                     raise
@@ -136,14 +147,6 @@ def run(slack_web_hook_url=None):
         target_arn = lambda_response["FunctionArn"]
         target_id = "Id" + str(randrange(10**11, 10**12))
 
-        # Remove targets and delete the CloudWatch rule before recreating it
-        rules = cw_events.list_rules(NamePrefix="GDPatrol")["Rules"]
-        for rule in rules:
-            if rule["Name"] == "GDPatrol":
-                targets = cw_events.list_targets_by_rule(Rule=rule["Name"])["Targets"]
-                for target in targets:
-                    cw_events.remove_targets(Rule=rule["Name"], Ids=[target["Id"]])
-                cw_events.delete_rule(Name="GDPatrol")
         created_rule = cw_events.put_rule(
             Name="GDPatrol",
             EventPattern='{"source":["aws.guardduty"],"detail-type":["GuardDuty Finding"]}',

--- a/deploy.py
+++ b/deploy.py
@@ -100,12 +100,23 @@ def run(slack_web_hook_url=None):
         lmb = boto3.client("lambda", region_name=region)
         cw_events = boto3.client("events", region_name=region)
         gd = boto3.client("guardduty", region_name=region)
-        if not gd.list_detectors()["DetectorIds"]:
+        detector_ids = gd.list_detectors()["DetectorIds"]
+        if not detector_ids:
             created_detector = gd.create_detector(Enable=True)
             print("Created GuardDuty detector: {}".format(created_detector["DetectorId"]))
         else:
-            gd.update_detector(DetectorId=gd.list_detectors()["DetectorIds"][0], Enable=True)
-            print("Detector already exists: {}".format(gd.list_detectors()["DetectorIds"][0]))
+            det_id = detector_ids[0]
+            # Only re-enable if it is actually disabled, and tolerate member/delegated-admin
+            # accounts where the member cannot manage detector enablement (the GuardDuty
+            # administrator account owns it) — update_detector raises BadRequestException there.
+            try:
+                if gd.get_detector(DetectorId=det_id).get("Status") != "ENABLED":
+                    gd.update_detector(DetectorId=det_id, Enable=True)
+                    print("Re-enabled GuardDuty detector: {}".format(det_id))
+                else:
+                    print("Detector already enabled: {}".format(det_id))
+            except Exception as e:
+                print("Could not manage detector {} (enablement may be org-managed): {}".format(det_id, e))
 
         sleep(7)  # Lambda bug: create function right after the role is created will cause AccessDeniedExceptionKMS error
         # A freshly created IAM role can take a while to propagate, and

--- a/lambda_policy.json
+++ b/lambda_policy.json
@@ -36,7 +36,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstances",
         "ec2:CreateSecurityGroup",
-        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifyNetworkInterfaceAttribute",
         "ec2:CreateNetworkAclEntry",
         "ec2:DescribeNetworkAcls"
       ],

--- a/lambda_policy.json
+++ b/lambda_policy.json
@@ -6,8 +6,6 @@
       "Action": [
         "ec2:RevokeSecurityGroupEgress",
         "ec2:CreateSnapshot",
-        "iam:PutUserPolicy",
-        "iam:DeleteUserPolicy",
         "ec2:DeleteNetworkAclEntry",
         "autoscaling:DetachInstances"
       ],
@@ -16,9 +14,21 @@
         "arn:aws:ec2:*:*:volume/*",
         "arn:aws:ec2:*:*:security-group/*",
         "arn:aws:ec2:*:*:network-acl/*",
-        "arn:aws:iam::*:user/*",
         "arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:PutUserPolicy",
+        "iam:DeleteUserPolicy"
+      ],
+      "Resource": "arn:aws:iam::*:user/*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PolicyName": ["BlockAllPolicy", "BlockEC2Policy", "BlockSecurityGroupPolicy"]
+        }
+      }
     },
     {
       "Effect": "Allow",
@@ -47,7 +57,10 @@
     {
       "Effect": "Allow",
       "Action": [
-        "dynamodb:*"
+        "dynamodb:Query",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:DeleteItem"
       ],
       "Resource": [
         "arn:aws:dynamodb:*:*:table/GDPatrol",

--- a/nacl_import.py
+++ b/nacl_import.py
@@ -1,28 +1,59 @@
 import boto3
 import time
 
-ec2 = boto3.client("ec2")
-dynamodb = boto3.client("dynamodb")
-nacls = ec2.describe_network_acls()
+TABLE_NAME = "GDPatrol"
 
-for nacl in nacls["NetworkAcls"]:
-    for rule in nacl["Entries"]:
-        if rule["Egress"] is False and rule["RuleAction"] == "deny":
+
+def _already_tracked(dynamodb, network_acl_id: str, rule_number: str) -> bool:
+    """Check whether a tracking row already exists for this NACL rule, so re-running this script is idempotent."""
+    response = dynamodb.query(
+        TableName=TABLE_NAME,
+        KeyConditionExpression="#pk = :pk_value",
+        FilterExpression="#rn = :rule_number",
+        ExpressionAttributeNames={"#pk": "network_acl_id", "#rn": "rule_number"},
+        ExpressionAttributeValues={
+            ":pk_value": {"S": network_acl_id},
+            ":rule_number": {"S": rule_number},
+        },
+    )
+    return bool(response.get("Items"))
+
+
+def seed_tracking_table():
+    ec2 = boto3.client("ec2")
+    dynamodb = boto3.client("dynamodb")
+    nacls = ec2.describe_network_acls()
+
+    for nacl in nacls["NetworkAcls"]:
+        for rule in nacl["Entries"]:
+            # Only track rules GDPatrol itself manages: ingress deny rules with a /32
+            # CidrBlock. This excludes AWS's implicit undeletable default-deny
+            # (0.0.0.0/0 @ rule 32767) and customer subnet-level denies, which would
+            # otherwise poison delete_oldest_acl_entry.
+            if rule["Egress"] or rule["RuleAction"] != "deny" or not rule.get("CidrBlock", "").endswith("/32"):
+                continue
+
+            network_acl_id = nacl["NetworkAclId"]
+            rule_number = str(rule["RuleNumber"])
+            if _already_tracked(dynamodb, network_acl_id, rule_number):
+                continue
+
             dynamodb.put_item(
-                TableName="GDPatrol",
+                TableName=TABLE_NAME,
                 Item={
                     "network_acl_id": {
-                        "S": nacl["NetworkAclId"],
+                        "S": network_acl_id,
                     },
                     "created_at": {
                         "S": str(time.time()),
                     },
                     "rule_number": {
-                        "S": str(rule["RuleNumber"]),
+                        "S": rule_number,
                     },
                 },
             )
-            print(nacl["NetworkAclId"])
-            print(time.time())
-            print(rule["RuleNumber"])
-            time.sleep(1)
+            print(f"Tracked {network_acl_id} rule {rule_number}")
+
+
+if __name__ == "__main__":
+    seed_tracking_table()

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,164 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import deploy
+
+REGIONS = ["us-east-1", "us-west-2", "eu-west-1"]
+
+
+class ResourceConflictException(Exception):
+    pass
+
+
+class InvalidParameterValueException(Exception):
+    pass
+
+
+class ResourceInUseException(Exception):
+    pass
+
+
+def _make_boto3_client_factory():
+    """boto3.client stand-in that returns a stable MagicMock per (service, region)
+    pair, so a test can configure/assert against a specific region's client."""
+    clients = {}
+
+    def fake_client(service_name, region_name=None, **kwargs):
+        key = (service_name, region_name)
+        if key not in clients:
+            clients[key] = MagicMock(name="{}:{}".format(service_name, region_name))
+        return clients[key]
+
+    return fake_client, clients
+
+
+def _seed_clients(fake_client, regions):
+    """Configure happy-path responses for every AWS client deploy.run() touches."""
+    ec2 = fake_client("ec2")
+    ec2.describe_regions.return_value = {"Regions": [{"RegionName": r} for r in regions]}
+
+    iam = fake_client("iam")
+    iam.get_paginator.return_value.paginate.return_value = [{"Roles": []}]
+    iam.create_role.return_value = {"Role": {"Arn": "arn:aws:iam::123456789012:role/GDPatrolRole"}}
+
+    for region in regions:
+        lmb = fake_client("lambda", region_name=region)
+        lmb.exceptions = SimpleNamespace(
+            ResourceConflictException=ResourceConflictException,
+            InvalidParameterValueException=InvalidParameterValueException,
+        )
+        function_arn = "arn:aws:lambda:{}:123456789012:function:GDPatrol".format(region)
+        lmb.create_function.return_value = {"FunctionArn": function_arn, "FunctionName": "GDPatrol"}
+        lmb.update_function_code.return_value = {"FunctionArn": function_arn, "FunctionName": "GDPatrol"}
+
+        events = fake_client("events", region_name=region)
+        events.put_rule.return_value = {"RuleArn": "arn:aws:events:{}:123456789012:rule/GDPatrol".format(region)}
+
+        gd = fake_client("guardduty", region_name=region)
+        gd.list_detectors.return_value = {"DetectorIds": ["detector-1"]}
+        gd.get_detector.return_value = {"Status": "ENABLED"}
+
+        ddb = fake_client("dynamodb", region_name=region)
+        ddb.exceptions = SimpleNamespace(ResourceInUseException=ResourceInUseException)
+
+
+@pytest.fixture
+def deploy_harness(monkeypatch, tmp_path):
+    """Mocked run() harness: boto3.client returns per-region MagicMocks, the zip
+    build is skipped, and sleep() is a no-op so tests run instantly."""
+    fake_client, clients = _make_boto3_client_factory()
+    monkeypatch.setattr(deploy.boto3, "client", fake_client)
+    monkeypatch.setattr(deploy, "sleep", lambda seconds: None)
+
+    zip_path = tmp_path / "GDPatrol.zip"
+    zip_path.write_bytes(b"PK\x03\x04fake-zip-contents")
+    monkeypatch.setattr(deploy, "build_function_zip", lambda: str(zip_path))
+
+    regions = list(REGIONS)
+    _seed_clients(fake_client, regions)
+
+    return SimpleNamespace(clients=clients, regions=regions)
+
+
+def test_region_failure_does_not_abort_remaining_regions(deploy_harness):
+    """Regression test for the isolation fix: one region's deploy raising must
+    not abort the rest of the rollout — this reproduces the two real outages
+    (a member-account detector error, a mid-run file deletion)."""
+    failing_region = deploy_harness.regions[1]
+    failing_lmb = deploy_harness.clients[("lambda", failing_region)]
+    failing_lmb.create_function.side_effect = RuntimeError("boom")
+    failing_lmb.update_function_code.side_effect = RuntimeError("boom")
+
+    deploy.run(slack_web_hook_url="https://hooks.slack.com/services/test")
+
+    for region in deploy_harness.regions:
+        if region == failing_region:
+            continue
+        lmb = deploy_harness.clients[("lambda", region)]
+        assert lmb.create_function.called
+
+
+def test_region_failure_is_reported_and_others_still_reported_successful(deploy_harness, capsys):
+    failing_region = deploy_harness.regions[1]
+    failing_lmb = deploy_harness.clients[("lambda", failing_region)]
+    failing_lmb.create_function.side_effect = RuntimeError("boom")
+    failing_lmb.update_function_code.side_effect = RuntimeError("boom")
+
+    deploy.run(slack_web_hook_url="https://hooks.slack.com/services/test")
+
+    out = capsys.readouterr().out
+    assert "Failed to deploy region {}: boom".format(failing_region) in out
+    for region in deploy_harness.regions:
+        if region != failing_region:
+            assert "Successfully deployed the GDPatrol lambda function in region {}".format(region) in out
+    assert failing_region not in out.split("Deploy summary:")[1].split("Failed:")[0]
+
+
+def test_guardduty_member_account_error_does_not_abort_region(deploy_harness):
+    """update_detector raising for a member/delegated-admin account (existing
+    try/except around detector management) must not block the region's deploy."""
+    region = deploy_harness.regions[0]
+    gd = deploy_harness.clients[("guardduty", region)]
+    gd.get_detector.return_value = {"Status": "DISABLED"}
+    gd.update_detector.side_effect = Exception("BadRequestException: member account")
+
+    deploy.run(slack_web_hook_url="https://hooks.slack.com/services/test")
+
+    lmb = deploy_harness.clients[("lambda", region)]
+    assert lmb.create_function.called
+
+
+def test_slack_webhook_env_var_included_when_set(deploy_harness, monkeypatch):
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/from-env")
+
+    deploy.run()
+
+    for region in deploy_harness.regions:
+        lmb = deploy_harness.clients[("lambda", region)]
+        env_vars = lmb.create_function.call_args.kwargs["Environment"]["Variables"]
+        assert env_vars["SLACK_WEB_HOOK_URL"] == "https://hooks.slack.com/services/from-env"
+
+
+def test_slack_webhook_env_var_absent_when_unset(deploy_harness, monkeypatch, capsys):
+    monkeypatch.delenv("SLACK_WEB_HOOK_URL", raising=False)
+
+    deploy.run()
+
+    for region in deploy_harness.regions:
+        lmb = deploy_harness.clients[("lambda", region)]
+        env_vars = lmb.create_function.call_args.kwargs["Environment"]["Variables"]
+        assert "SLACK_WEB_HOOK_URL" not in env_vars
+    assert "WARNING: SLACK_WEB_HOOK_URL is not set" in capsys.readouterr().out
+
+
+def test_create_conflict_falls_back_to_update(deploy_harness):
+    region = deploy_harness.regions[0]
+    lmb = deploy_harness.clients[("lambda", region)]
+    lmb.create_function.side_effect = ResourceConflictException("already exists")
+
+    deploy.run(slack_web_hook_url="https://hooks.slack.com/services/test")
+
+    assert lmb.update_function_code.called
+    assert lmb.update_function_configuration.called

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,7 +1,13 @@
+import os
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+
+# deploy.py lives at the repo root; make it importable however pytest is invoked
+# (CI runs the pytest console script, so the repo root isn't auto-added to sys.path).
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import deploy
 

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -25,6 +25,7 @@ from GDPatrol.lambda_function import (
     enable_ec2_access,
     disable_sg_access,
     enable_sg_access,
+    _next_free_ingress_deny_rule_number,
     Config,
     lambda_handler,
 )
@@ -307,6 +308,161 @@ def test_blacklist_ip_parameterized(mock_boto3_client, ip_address, expected, moc
         assert blacklist_ip(ip_address) is False
 
 
+def test_blacklist_ip_skips_colliding_allow_rule(mock_ec2_client, mock_dynamodb_client):
+    """The preferred rule number must never collide with, or evict, a pre-existing ALLOW rule."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    nacl = mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    nacl_id = nacl["NetworkAcl"]["NetworkAclId"]
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+
+    # An existing GDPatrol deny rule at 100, and a customer ALLOW rule sitting exactly
+    # at the preferred next slot (99).
+    mock_ec2_client.create_network_acl_entry(
+        CidrBlock="9.9.9.9/32", Egress=False, NetworkAclId=nacl_id, Protocol="-1", RuleAction="deny", RuleNumber=100
+    )
+    mock_ec2_client.create_network_acl_entry(
+        CidrBlock="10.0.0.0/24", Egress=False, NetworkAclId=nacl_id, Protocol="-1", RuleAction="allow", RuleNumber=99
+    )
+
+    assert blacklist_ip("203.0.113.5") is True
+
+    entries = mock_ec2_client.describe_network_acls(NetworkAclIds=[nacl_id])["NetworkAcls"][0]["Entries"]
+    new_rule = next(e for e in entries if e.get("CidrBlock") == "203.0.113.5/32")
+    assert new_rule["RuleNumber"] == 98
+    assert any(e["RuleNumber"] == 99 and e["RuleAction"] == "allow" for e in entries), "pre-existing allow rule was evicted"
+
+
+def test_blacklist_ip_low_end_exhaustion_does_not_evict(mock_ec2_client, mock_dynamodb_client):
+    """When the low end is exhausted, blacklist_ip must search the high end instead of evicting
+    whoever holds the old hardcoded wraparound slot (32700)."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    nacl = mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    nacl_id = nacl["NetworkAcl"]["NetworkAclId"]
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+
+    # A GDPatrol deny rule already sits at the lowest usable number.
+    mock_ec2_client.create_network_acl_entry(
+        CidrBlock="9.9.9.9/32", Egress=False, NetworkAclId=nacl_id, Protocol="-1", RuleAction="deny", RuleNumber=1
+    )
+    # Something else already occupies the old hardcoded wraparound target.
+    mock_ec2_client.create_network_acl_entry(
+        CidrBlock="10.0.5.0/24", Egress=False, NetworkAclId=nacl_id, Protocol="-1", RuleAction="deny", RuleNumber=32700
+    )
+
+    assert blacklist_ip("203.0.113.6") is True
+
+    entries = mock_ec2_client.describe_network_acls(NetworkAclIds=[nacl_id])["NetworkAcls"][0]["Entries"]
+    assert any(e["RuleNumber"] == 32700 and e.get("CidrBlock") == "10.0.5.0/24" for e in entries), (
+        "pre-existing occupant of rule 32700 was evicted"
+    )
+    new_rule = next(e for e in entries if e.get("CidrBlock") == "203.0.113.6/32")
+    assert new_rule["RuleNumber"] == 32766
+
+
+@patch("GDPatrol.lambda_function.dynamodb_client")
+@patch("GDPatrol.lambda_function.delete_oldest_acl_entry")
+@patch("GDPatrol.lambda_function.create_network_acl_entry")
+@patch("GDPatrol.lambda_function._next_free_ingress_deny_rule_number")
+@patch("GDPatrol.lambda_function.ec2_client")
+def test_blacklist_ip_cleans_up_when_no_free_rule_number(mock_ec2, mock_next_free, mock_create_entry, mock_delete_oldest, mock_dynamo):
+    """When the helper reports no free rule number, blacklist_ip must delete the oldest entry and retry."""
+    nacl = {"NetworkAclId": "acl-1", "Entries": [{"Egress": False, "RuleAction": "deny", "RuleNumber": 5, "CidrBlock": "9.9.9.9/32"}]}
+    mock_ec2.get_paginator.return_value.paginate.return_value = [{"NetworkAcls": [nacl]}]
+    mock_ec2.describe_network_acls.return_value = {"NetworkAcls": [nacl]}
+    mock_next_free.side_effect = [None, 42]
+    mock_dynamo.exceptions = MagicMock()
+
+    with patch("GDPatrol.lambda_function.acquire_lock"), patch("GDPatrol.lambda_function.release_lock"):
+        result = blacklist_ip("10.0.0.1")
+
+    mock_delete_oldest.assert_called_once_with("acl-1")
+    mock_create_entry.assert_called_once_with("10.0.0.1", "acl-1", 42)
+    assert result is True
+
+
+@patch("GDPatrol.lambda_function.dynamodb_client")
+@patch("GDPatrol.lambda_function.create_network_acl_entry")
+@patch("GDPatrol.lambda_function._next_free_ingress_deny_rule_number")
+@patch("GDPatrol.lambda_function.ec2_client")
+def test_blacklist_ip_retries_on_already_exists(mock_ec2, mock_next_free, mock_create_entry, mock_dynamo):
+    """A NetworkAclEntryAlreadyExists error on create must retry with a fresh free number, not fail
+    the whole NACL silently."""
+    from botocore.exceptions import ClientError
+
+    nacl = {"NetworkAclId": "acl-1", "Entries": []}
+    mock_ec2.get_paginator.return_value.paginate.return_value = [{"NetworkAcls": [nacl]}]
+    mock_ec2.describe_network_acls.return_value = {"NetworkAcls": [nacl]}
+    mock_next_free.side_effect = [99, 98]  # first choice collides, second is fresh
+    mock_create_entry.side_effect = [
+        ClientError({"Error": {"Code": "NetworkAclEntryAlreadyExists", "Message": "x"}}, "CreateNetworkAclEntry"),
+        None,
+    ]
+    mock_dynamo.exceptions = MagicMock()
+
+    with patch("GDPatrol.lambda_function.acquire_lock"), patch("GDPatrol.lambda_function.release_lock"):
+        result = blacklist_ip("10.0.0.1")
+
+    assert result is True
+    assert mock_create_entry.call_args_list[0].args[2] == 99
+    assert mock_create_entry.call_args_list[1].args[2] == 98
+
+
+# --- _next_free_ingress_deny_rule_number tests ---
+
+
+def _acl_entry(rule_number, egress=False, action="deny", cidr="1.2.3.4/32"):
+    return {"RuleNumber": rule_number, "Egress": egress, "RuleAction": action, "CidrBlock": cidr}
+
+
+def test_next_free_rule_number_empty_nacl():
+    """With no entries at all, the first GDPatrol deny rule starts at 100."""
+    assert _next_free_ingress_deny_rule_number([]) == 100
+
+
+def test_next_free_rule_number_prefers_one_below_lowest_deny():
+    """The decrement scheme: a new rule goes one below the current lowest GDPatrol deny rule."""
+    entries = [_acl_entry(50)]
+    assert _next_free_ingress_deny_rule_number(entries) == 49
+
+
+def test_next_free_rule_number_skips_allow_rule_collision():
+    """A pre-existing ALLOW rule at the preferred slot must not be evicted or collided with."""
+    entries = [_acl_entry(50), _acl_entry(49, action="allow", cidr="0.0.0.0/0")]
+    assert _next_free_ingress_deny_rule_number(entries) == 48
+
+
+def test_next_free_rule_number_ignores_egress_entries():
+    """Egress and ingress rule numbers are independent namespaces; an egress rule must not block ingress."""
+    entries = [_acl_entry(50), _acl_entry(49, egress=True, action="allow", cidr="0.0.0.0/0")]
+    assert _next_free_ingress_deny_rule_number(entries) == 49
+
+
+def test_next_free_rule_number_low_end_exhaustion_falls_back_to_high_range():
+    """When the lowest deny rule is 1, decrementing below it is impossible; search the high end instead."""
+    entries = [_acl_entry(1)]
+    assert _next_free_ingress_deny_rule_number(entries) == 32766
+
+
+def test_next_free_rule_number_low_range_fully_occupied_falls_back_to_high_range():
+    """Even if the preferred slot isn't literally 0, a fully-occupied low range must fall back high."""
+    entries = [_acl_entry(3)] + [_acl_entry(n, action="allow", cidr="0.0.0.0/0") for n in (1, 2)]
+    assert _next_free_ingress_deny_rule_number(entries) == 32766
+
+
+def test_next_free_rule_number_high_range_skips_occupied_slots():
+    """The high-end search must also skip numbers that are already taken."""
+    entries = [_acl_entry(1), _acl_entry(32766, action="allow", cidr="0.0.0.0/0")]
+    assert _next_free_ingress_deny_rule_number(entries) == 32765
+
+
+def test_next_free_rule_number_fully_occupied_nacl_returns_none():
+    """A NACL with every ingress rule number taken must return None so the caller triggers cleanup."""
+    entries = [_acl_entry(n) for n in range(1, 32767)]
+    assert _next_free_ingress_deny_rule_number(entries) is None
+
+
 # --- delete_oldest_acl_entry tests ---
 
 
@@ -351,7 +507,33 @@ def test_delete_oldest_acl_entry_fallback_to_aws(mock_ec2, mock_dynamo):
 
     mock_ec2.delete_network_acl_entry.assert_called_once()
     call_kwargs = mock_ec2.delete_network_acl_entry.call_args[1]
-    assert call_kwargs["RuleNumber"] == 10  # lowest deny rule
+    # New rules get decreasing numbers, so the HIGHEST rule number is the oldest.
+    assert call_kwargs["RuleNumber"] == 20
+
+
+@patch("GDPatrol.lambda_function.dynamodb_client")
+@patch("GDPatrol.lambda_function.ec2_client")
+def test_delete_oldest_acl_entry_fallback_excludes_non_gdpatrol_rules(mock_ec2, mock_dynamo):
+    """Only /32 GDPatrol-managed deny rules are candidates for deletion — the implicit
+    default-deny (0.0.0.0/0 @ 32767) and customer subnet-level denies must be left alone."""
+    mock_dynamo.query.return_value = {"Items": []}
+    mock_ec2.describe_network_acls.return_value = {
+        "NetworkAcls": [
+            {
+                "Entries": [
+                    {"Egress": False, "RuleAction": "deny", "RuleNumber": 10, "CidrBlock": "1.2.3.4/32"},
+                    {"Egress": False, "RuleAction": "deny", "RuleNumber": 32767, "CidrBlock": "0.0.0.0/0"},
+                    {"Egress": False, "RuleAction": "deny", "RuleNumber": 5, "CidrBlock": "10.0.0.0/24"},
+                ]
+            }
+        ]
+    }
+
+    delete_oldest_acl_entry("acl-123")
+
+    mock_ec2.delete_network_acl_entry.assert_called_once()
+    call_kwargs = mock_ec2.delete_network_acl_entry.call_args[1]
+    assert call_kwargs["RuleNumber"] == 10  # the only /32 GDPatrol-managed rule
 
 
 @patch("GDPatrol.lambda_function.dynamodb_client")
@@ -372,6 +554,46 @@ def test_delete_oldest_acl_entry_no_deny_rules(mock_ec2, mock_dynamo):
     delete_oldest_acl_entry("acl-123")
 
     mock_ec2.delete_network_acl_entry.assert_not_called()
+
+
+@patch("GDPatrol.lambda_function.dynamodb_client")
+@patch("GDPatrol.lambda_function.ec2_client")
+def test_delete_oldest_acl_entry_reconciles_stale_dynamodb_row(mock_ec2, mock_dynamo):
+    """If AWS no longer has the tracked rule, the stale DynamoDB row must still be deleted so it
+    doesn't keep winning as 'oldest' forever."""
+    from botocore.exceptions import ClientError
+
+    mock_dynamo.query.return_value = {
+        "Items": [{"network_acl_id": {"S": "acl-123"}, "created_at": {"S": "1000.0"}, "rule_number": {"S": "50"}}]
+    }
+    mock_ec2.delete_network_acl_entry.side_effect = ClientError(
+        {"Error": {"Code": "InvalidNetworkAclEntry.NotFound", "Message": "not found"}}, "DeleteNetworkAclEntry"
+    )
+
+    delete_oldest_acl_entry("acl-123")
+
+    mock_dynamo.delete_item.assert_called_once_with(
+        TableName="GDPatrol",
+        Key={"network_acl_id": {"S": "acl-123"}, "created_at": {"S": "1000.0"}},
+    )
+
+
+@patch("GDPatrol.lambda_function.dynamodb_client")
+@patch("GDPatrol.lambda_function.ec2_client")
+def test_delete_oldest_acl_entry_other_errors_do_not_touch_dynamodb(mock_ec2, mock_dynamo):
+    """A non-NotFound AWS error must not be treated as drift — the DynamoDB row must survive for retry."""
+    from botocore.exceptions import ClientError
+
+    mock_dynamo.query.return_value = {
+        "Items": [{"network_acl_id": {"S": "acl-123"}, "created_at": {"S": "1000.0"}, "rule_number": {"S": "50"}}]
+    }
+    mock_ec2.delete_network_acl_entry.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "nope"}}, "DeleteNetworkAclEntry"
+    )
+
+    delete_oldest_acl_entry("acl-123")
+
+    mock_dynamo.delete_item.assert_not_called()
 
 
 # --- Lock tests ---

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -1098,6 +1098,43 @@ def test_lambda_handler_survives_missing_slack_fields(monkeypatch):
         mock_publish.assert_called_once()
 
 
+def test_lambda_handler_string_severity_does_not_crash_notify(monkeypatch):
+    """A numeric-string severity must not crash the notify gate after actions have run."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")
+
+    event = {
+        "id": "test-id",
+        "type": "Discovery:RDS/MaliciousIPCaller",
+        "severity": "9",  # arrives as a string, not a number
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "resource": {
+            "resourceType": "RDSDBInstance",
+            "rdsDbInstanceDetails": {"dbInstanceIdentifier": "testdb", "engine": "mysql"},
+        },
+        "service": {
+            "action": {
+                "actionType": "RDS_LOGIN_ATTEMPT",
+                "rdsLoginAttemptAction": {"remoteIpDetails": {"ipAddressV4": "1.2.3.4"}},
+            },
+            "count": 1,
+            "eventFirstSeen": "x",
+            "eventLastSeen": "y",
+        },
+        "description": "RDS finding",
+    }
+
+    test_config_path = Path(__file__).parent / "test_config.json"
+    with (
+        patch("builtins.open", MagicMock()) as mock_open,
+        patch("GDPatrol.lambda_function.publish_message") as mock_publish,
+        patch("GDPatrol.lambda_function.blacklist_ip", return_value=True),
+    ):
+        mock_open.return_value.__enter__.return_value.read.return_value = test_config_path.read_text()
+        lambda_handler(event, None)  # must not raise (severity "9" would fail "9" > 5)
+        mock_publish.assert_called_once()
+
+
 def test_lambda_handler_survives_config_load_error():
     """A missing or malformed config.json must be logged, not crash the invocation."""
     event = {

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -1135,6 +1135,29 @@ def test_lambda_handler_string_severity_does_not_crash_notify(monkeypatch):
         mock_publish.assert_called_once()
 
 
+def test_lambda_policy_grants_ec2_actions_the_code_calls():
+    """The execution policy must grant every EC2 mutating action the remediation code calls.
+    Guards against a code change (e.g. the multi-ENI quarantine switching to
+    modify_network_interface_attribute) that the IAM policy isn't updated to match --
+    a gap moto can't catch because it doesn't enforce IAM."""
+    policy = json.loads((Path(__file__).parent.parent / "lambda_policy.json").read_text())
+    granted = set()
+    for stmt in policy["Statement"]:
+        actions = stmt["Action"]
+        granted.update(actions if isinstance(actions, list) else [actions])
+    required = {
+        "ec2:CreateSecurityGroup",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:CreateSnapshot",
+        "ec2:CreateNetworkAclEntry",
+        "ec2:DeleteNetworkAclEntry",
+        "ec2:DescribeInstances",
+        "ec2:DescribeNetworkAcls",
+    }
+    assert not (required - granted), f"lambda_policy.json missing required actions: {required - granted}"
+
+
 def test_lambda_handler_survives_config_load_error():
     """A missing or malformed config.json must be logged, not crash the invocation."""
     event = {

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+import time
 from unittest.mock import patch, MagicMock
 import sys
 import os
@@ -390,14 +391,71 @@ def test_acquire_and_release_lock(mock_dynamo):
     mock_dynamo.delete_item.assert_called_once()
 
 
+@patch("GDPatrol.lambda_function.time.sleep", return_value=None)
+@patch("GDPatrol.lambda_function.dynamodb_client")
+def test_acquire_lock_queues_through_a_burst(mock_dynamo, mock_sleep):
+    """A burst of contention must queue past the old 5-attempt budget instead of failing to acquire."""
+    busy_attempts = 10  # more than the old default max_retries of 5
+    call_count = {"n": 0}
+
+    def get_item_side_effect(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] <= busy_attempts:
+            return {"Item": {"timestamp": {"S": str(int(time.time()))}}}
+        return {}
+
+    mock_dynamo.get_item.side_effect = get_item_side_effect
+    mock_dynamo.exceptions = MagicMock()
+    mock_dynamo.exceptions.ConditionalCheckFailedException = type("ConditionalCheckFailedException", (Exception,), {})
+
+    acquire_lock("GDPatrol_lock", "gdpatrol-nacl")
+
+    mock_dynamo.put_item.assert_called_once()
+
+
+@patch("GDPatrol.lambda_function.release_lock")
+@patch("GDPatrol.lambda_function.acquire_lock")
+def test_blacklist_ip_uses_shared_lock_id(mock_acquire, mock_release):
+    """Two different IPs must serialize on the SAME lock id, not per-IP locks, since blacklist_ip mutates every NACL."""
+    mock_acquire.side_effect = Exception("boom")
+    blacklist_ip("10.0.0.1")
+    blacklist_ip("10.0.0.2")
+
+    lock_ids_used = {call.args[1] for call in mock_acquire.call_args_list}
+    assert lock_ids_used == {"gdpatrol-nacl"}
+
+
+@patch("GDPatrol.lambda_function.release_lock")
+@patch("GDPatrol.lambda_function.acquire_lock")
+def test_whitelist_ip_uses_lock(mock_acquire, mock_release, mock_ec2_client):
+    """whitelist_ip must serialize its NACL mutations under the same shared lock as blacklist_ip."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+
+    whitelist_ip("192.168.1.1")
+
+    mock_acquire.assert_called_once_with(os.environ.get("GD_PATROL_LOCK_TABLE", "GDPatrol_lock"), "gdpatrol-nacl")
+    mock_release.assert_called_once()
+
+
+@patch("GDPatrol.lambda_function.release_lock")
+@patch("GDPatrol.lambda_function.acquire_lock")
+def test_whitelist_ip_no_release_when_acquire_fails(mock_acquire, mock_release):
+    """A failed acquire_lock must not release another invocation's lock."""
+    mock_acquire.side_effect = Exception("Unable to acquire lock after multiple attempts")
+    assert whitelist_ip("198.51.100.1") is False
+    mock_release.assert_not_called()
+
+
 # --- whitelist_ip tests ---
 
 
-def test_whitelist_ip(mock_ec2_client):
+def test_whitelist_ip(mock_ec2_client, mock_dynamodb_client):
     """Test whitelisting (removing) an IP from NACLs."""
     vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
     nacl = mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
     nacl_id = nacl["NetworkAcl"]["NetworkAclId"]
+    create_lock_table(mock_dynamodb_client)
 
     # Add a deny rule first
     mock_ec2_client.create_network_acl_entry(

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 import time
+import socket
 from unittest.mock import patch, MagicMock
 import sys
 import os
@@ -27,6 +28,7 @@ from GDPatrol.lambda_function import (
     enable_sg_access,
     asg_detach_instance,
     _next_free_ingress_deny_rule_number,
+    resolve_domain_a_records,
     Config,
     lambda_handler,
 )
@@ -1007,3 +1009,144 @@ def test_lambda_handler_iam_finding(monkeypatch):
         mock_disable.return_value = True
         lambda_handler(event, None)
         mock_disable.assert_called_once_with("baduser")
+
+
+def test_lambda_handler_fractional_severity_crosses_gate(monkeypatch):
+    """A fractional severity like 5.5 must not be truncated to 5, which would under-count the reliability gate."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")
+
+    event = {
+        "id": "test-id",
+        "type": "Discovery:RDS/MaliciousIPCaller",
+        "severity": 5.5,
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "resource": {
+            "resourceType": "RDSDBInstance",
+            "rdsDbInstanceDetails": {"dbInstanceIdentifier": "testdb", "engine": "mysql"},
+        },
+        "service": {
+            "action": {
+                "actionType": "RDS_LOGIN_ATTEMPT",
+                "rdsLoginAttemptAction": {"remoteIpDetails": {"ipAddressV4": "1.2.3.4"}},
+            },
+            "count": 1,
+            "eventFirstSeen": "2024-01-01T00:00:00Z",
+            "eventLastSeen": "2024-01-01T00:00:00Z",
+        },
+        "description": "RDS finding",
+    }
+
+    # test_config.json reliability for this type is 5. int(5.5) + 5 = 10, NOT > 10 (bug);
+    # float(5.5) + 5 = 10.5 > 10 (fixed) — must trigger blacklist_ip.
+    test_config_path = Path(__file__).parent / "test_config.json"
+    with (
+        patch("builtins.open", MagicMock()) as mock_open,
+        patch("GDPatrol.lambda_function.publish_message"),
+        patch("GDPatrol.lambda_function.blacklist_ip") as mock_blacklist,
+    ):
+        mock_open.return_value.__enter__.return_value.read.return_value = test_config_path.read_text()
+        mock_blacklist.return_value = True
+        lambda_handler(event, None)
+        mock_blacklist.assert_called_once_with("1.2.3.4")
+
+
+def test_lambda_handler_survives_missing_slack_fields(monkeypatch):
+    """Missing service.count/eventFirstSeen/eventLastSeen must not crash the handler after actions have run."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")
+
+    event = {
+        "id": "test-id",
+        "type": "Discovery:RDS/MaliciousIPCaller",
+        "severity": 8,
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "resource": {
+            "resourceType": "RDSDBInstance",
+            "rdsDbInstanceDetails": {"dbInstanceIdentifier": "testdb", "engine": "mysql"},
+        },
+        "service": {
+            "action": {
+                "actionType": "RDS_LOGIN_ATTEMPT",
+                "rdsLoginAttemptAction": {"remoteIpDetails": {"ipAddressV4": "1.2.3.4"}},
+            },
+            # count, eventFirstSeen, eventLastSeen intentionally omitted
+        },
+        "description": "RDS finding",
+    }
+
+    test_config_path = Path(__file__).parent / "test_config.json"
+    with (
+        patch("builtins.open", MagicMock()) as mock_open,
+        patch("GDPatrol.lambda_function.publish_message") as mock_publish,
+        patch("GDPatrol.lambda_function.blacklist_ip", return_value=True),
+    ):
+        mock_open.return_value.__enter__.return_value.read.return_value = test_config_path.read_text()
+        lambda_handler(event, None)  # must not raise
+        mock_publish.assert_called_once()
+
+
+def test_lambda_handler_survives_config_load_error():
+    """A missing or malformed config.json must be logged, not crash the invocation."""
+    event = {
+        "id": "test-id",
+        "type": "SomeType",
+        "severity": 8,
+        "service": {"action": {}, "count": 1, "eventFirstSeen": "x", "eventLastSeen": "y"},
+    }
+    with patch("builtins.open", side_effect=FileNotFoundError("config.json missing")):
+        lambda_handler(event, None)  # must not raise
+
+
+# --- resolve_domain_a_records tests ---
+
+
+def test_resolve_domain_a_records_returns_all_unique_ips():
+    """All resolved A records must be returned, not just the first."""
+    fake_results = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 0)),
+        (socket.AF_INET, socket.SOCK_DGRAM, 17, "", ("1.2.3.4", 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("5.6.7.8", 0)),
+    ]
+    with patch("GDPatrol.lambda_function.socket.getaddrinfo", return_value=fake_results) as mock_getaddrinfo:
+        ips = resolve_domain_a_records("malicious.example.com")
+
+    assert set(ips) == {"1.2.3.4", "5.6.7.8"}
+    mock_getaddrinfo.assert_called_once()
+
+
+def test_resolve_domain_a_records_sets_and_restores_timeout():
+    """A bounded timeout must be applied around resolution, then restored, so a hostile
+    nameserver can't hang the invocation or leak the timeout to unrelated code."""
+    original = socket.getdefaulttimeout()
+    with patch("GDPatrol.lambda_function.socket.getaddrinfo", return_value=[]):
+        resolve_domain_a_records("example.com", timeout=3)
+    assert socket.getdefaulttimeout() == original
+
+
+def test_resolve_domain_a_records_handles_resolution_errors():
+    """DNS failures, including a timeout, must be swallowed, returning no addresses rather than raising."""
+    with patch("GDPatrol.lambda_function.socket.getaddrinfo", side_effect=socket.gaierror("no such host")):
+        assert resolve_domain_a_records("nonexistent.example.com") == []
+
+    with patch("GDPatrol.lambda_function.socket.getaddrinfo", side_effect=socket.timeout("timed out")):
+        assert resolve_domain_a_records("slow.example.com") == []
+
+
+def test_lambda_handler_blacklist_domain_blocks_all_resolved_ips(sample_guardduty_event, monkeypatch):
+    """blacklist_domain must resolve and attempt to block every A record, not just the first."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")
+
+    test_config_path = Path(__file__).parent / "test_config.json"
+    with (
+        patch("builtins.open", MagicMock()) as mock_open,
+        patch("GDPatrol.lambda_function.publish_message"),
+        patch("GDPatrol.lambda_function.resolve_domain_a_records", return_value=["1.2.3.4", "5.6.7.8"]),
+        patch("GDPatrol.lambda_function.blacklist_ip", return_value=True) as mock_blacklist,
+    ):
+        mock_open.return_value.__enter__.return_value.read.return_value = test_config_path.read_text()
+        lambda_handler(sample_guardduty_event, None)
+
+        assert mock_blacklist.call_count == 2
+        mock_blacklist.assert_any_call("1.2.3.4")
+        mock_blacklist.assert_any_call("5.6.7.8")

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -193,6 +193,30 @@ def test_blacklist_ip_blocks_all_nacls(mock_ec2_client, mock_dynamodb_client):
         )
 
 
+def test_aggressive_cleanup_scales_with_configured_limit(mock_ec2_client, mock_dynamodb_client):
+    """The cleanup trigger (limit-1) and keep-count (limit//2) follow NACL_RULE_LIMIT."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    nacl_id = mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])["NetworkAcl"]["NetworkAclId"]
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+    # Seed 5 GDPatrol /32 deny rules. With NACL_RULE_LIMIT=6 the trigger is >=5, so
+    # blocking one more fires aggressive cleanup (keep 6//2=3, evict the rest).
+    for i, rn in enumerate(range(100, 95, -1)):
+        mock_ec2_client.create_network_acl_entry(
+            CidrBlock=f"10.0.0.{i}/32", Egress=False, NetworkAclId=nacl_id, Protocol="-1", RuleAction="deny", RuleNumber=rn
+        )
+    with patch("GDPatrol.lambda_function.NACL_RULE_LIMIT", 6):
+        assert blacklist_ip("203.0.113.50") is True
+    deny = [
+        e
+        for e in mock_ec2_client.describe_network_acls(NetworkAclIds=[nacl_id])["NetworkAcls"][0]["Entries"]
+        if not e["Egress"] and e["RuleAction"] == "deny" and e.get("CidrBlock", "").endswith("/32")
+    ]
+    # Without cleanup it would be 6 (5 old + new); cleanup kept 3 old + added the new = 4.
+    assert len(deny) <= 4, f"cleanup did not cap to the configured limit: {len(deny)} rules"
+    assert any(e["CidrBlock"] == "203.0.113.50/32" for e in deny)
+
+
 @patch("GDPatrol.lambda_function.release_lock")
 @patch("GDPatrol.lambda_function.acquire_lock")
 def test_blacklist_ip_no_release_when_acquire_fails(mock_acquire, mock_release):

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -376,6 +376,73 @@ def test_blacklist_ip_low_end_exhaustion_does_not_evict(mock_ec2_client, mock_dy
     assert new_rule["RuleNumber"] == 32766
 
 
+def test_blacklist_ip_aggressive_cleanup_never_deletes_customer_rule(mock_ec2_client, mock_dynamodb_client):
+    """Aggressive cleanup must only ever consider GDPatrol-managed (/32 ingress deny) rules —
+    a customer's own deny rule (e.g. a subnet-level block) must never be swept up, even when it
+    pushes the NACL's total deny-rule count over the cleanup threshold."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    nacl = mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    nacl_id = nacl["NetworkAcl"]["NetworkAclId"]
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+
+    # Customer's own subnet-level deny rule — GDPatrol must never touch this.
+    mock_ec2_client.create_network_acl_entry(
+        CidrBlock="10.0.0.0/24", Egress=False, NetworkAclId=nacl_id, Protocol="-1", RuleAction="deny", RuleNumber=500
+    )
+    # 19 GDPatrol-managed /32 deny rules, enough to trigger the aggressive-cleanup threshold.
+    for i in range(1, 20):
+        mock_ec2_client.create_network_acl_entry(
+            CidrBlock=f"10.1.0.{i}/32", Egress=False, NetworkAclId=nacl_id, Protocol="-1", RuleAction="deny", RuleNumber=i
+        )
+
+    assert blacklist_ip("203.0.113.50") is True
+
+    entries = mock_ec2_client.describe_network_acls(NetworkAclIds=[nacl_id])["NetworkAcls"][0]["Entries"]
+    assert any(e["RuleNumber"] == 500 and e.get("CidrBlock") == "10.0.0.0/24" for e in entries), (
+        "customer's own deny rule was swept up by aggressive cleanup"
+    )
+
+
+def test_blacklist_ip_aggressive_cleanup_orders_by_created_at_not_rule_number(mock_ec2_client, mock_dynamodb_client):
+    """Aggressive cleanup must evict the oldest rules by DynamoDB created_at, not by rule number —
+    the allocator can hand a high rule number to a brand-new rule once the low range is exhausted,
+    so 'lowest rule number' no longer means 'newest'."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    nacl = mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    nacl_id = nacl["NetworkAcl"]["NetworkAclId"]
+    create_gdpatrol_table(mock_dynamodb_client)
+    create_lock_table(mock_dynamodb_client)
+
+    def add_tracked_rule(rule_number, created_at, cidr):
+        mock_ec2_client.create_network_acl_entry(
+            CidrBlock=cidr, Egress=False, NetworkAclId=nacl_id, Protocol="-1", RuleAction="deny", RuleNumber=rule_number
+        )
+        mock_dynamodb_client.put_item(
+            TableName="GDPatrol",
+            Item={
+                "network_acl_id": {"S": nacl_id},
+                "created_at": {"S": created_at},
+                "rule_number": {"S": str(rule_number)},
+            },
+        )
+
+    # Oldest rule holds a LOW rule number.
+    add_tracked_rule(5, "1.0", "10.1.0.5/32")
+    # Newest rule holds a HIGH rule number, as the allocator hands out once the low range is exhausted.
+    add_tracked_rule(32760, "300.0", "10.1.0.250/32")
+    # 17 filler rules in between, to reach the 19-rule cleanup threshold.
+    for i in range(17):
+        add_tracked_rule(101 + i, str(200 + i), f"10.1.1.{i}/32")
+
+    assert blacklist_ip("203.0.113.60") is True
+
+    entries = mock_ec2_client.describe_network_acls(NetworkAclIds=[nacl_id])["NetworkAcls"][0]["Entries"]
+    rule_numbers = {e["RuleNumber"] for e in entries if not e["Egress"] and e["RuleAction"] == "deny"}
+    assert 32760 in rule_numbers, "newest rule (high rule number) was wrongly evicted"
+    assert 5 not in rule_numbers, "oldest rule (low rule number) should have been evicted, not kept"
+
+
 @patch("GDPatrol.lambda_function.dynamodb_client")
 @patch("GDPatrol.lambda_function.delete_oldest_acl_entry")
 @patch("GDPatrol.lambda_function.create_network_acl_entry")

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -25,6 +25,7 @@ from GDPatrol.lambda_function import (
     enable_ec2_access,
     disable_sg_access,
     enable_sg_access,
+    asg_detach_instance,
     _next_free_ingress_deny_rule_number,
     Config,
     lambda_handler,
@@ -697,6 +698,20 @@ def test_whitelist_ip(mock_ec2_client, mock_dynamodb_client):
     assert not any(e.get("CidrBlock") == "192.168.1.1/32" and e["RuleAction"] == "deny" for e in entries)
 
 
+def test_whitelist_ip_invalid_ip_returns_false():
+    """An invalid IP must be rejected before touching any NACLs."""
+    assert whitelist_ip("not-an-ip") is False
+
+
+def test_whitelist_ip_no_matching_rules_returns_false(mock_ec2_client, mock_dynamodb_client):
+    """Whitelisting an IP with no matching rule anywhere is a no-op and must return False, not True."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])
+    create_lock_table(mock_dynamodb_client)
+
+    assert whitelist_ip("203.0.113.200") is False
+
+
 # --- IAM action tests ---
 
 
@@ -797,10 +812,36 @@ def test_quarantine_instance(mock_ec2_client):
     result = quarantine_instance(instance_id, vpc["Vpc"]["VpcId"])
     assert result is True
 
-    # Verify instance has a quarantine security group
+    # Verify the instance's (only) network interface has the quarantine security group
     instance_desc = mock_ec2_client.describe_instances(InstanceIds=[instance_id])
-    sgs = instance_desc["Reservations"][0]["Instances"][0]["SecurityGroups"]
-    assert any("Quarantine" in sg["GroupName"] for sg in sgs)
+    nics = instance_desc["Reservations"][0]["Instances"][0]["NetworkInterfaces"]
+    assert len(nics) == 1
+    assert any("Quarantine" in g["GroupName"] for g in nics[0]["Groups"])
+
+
+def test_quarantine_instance_isolates_every_eni(mock_ec2_client):
+    """An instance with multiple ENIs must have the quarantine SG applied to ALL of them, not just the primary."""
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    subnet = mock_ec2_client.create_subnet(VpcId=vpc["Vpc"]["VpcId"], CidrBlock="10.0.1.0/24")
+    instance = mock_ec2_client.run_instances(
+        ImageId="ami-12345678",
+        MinCount=1,
+        MaxCount=1,
+        SubnetId=subnet["Subnet"]["SubnetId"],
+    )
+    instance_id = instance["Instances"][0]["InstanceId"]
+
+    second_eni = mock_ec2_client.create_network_interface(SubnetId=subnet["Subnet"]["SubnetId"])["NetworkInterface"]
+    mock_ec2_client.attach_network_interface(NetworkInterfaceId=second_eni["NetworkInterfaceId"], InstanceId=instance_id, DeviceIndex=1)
+
+    result = quarantine_instance(instance_id, vpc["Vpc"]["VpcId"])
+    assert result is True
+
+    instance_desc = mock_ec2_client.describe_instances(InstanceIds=[instance_id])
+    nics = instance_desc["Reservations"][0]["Instances"][0]["NetworkInterfaces"]
+    assert len(nics) == 2
+    for nic in nics:
+        assert any("Quarantine" in g["GroupName"] for g in nic["Groups"]), f"ENI {nic['NetworkInterfaceId']} was not quarantined"
 
 
 def test_snapshot_instance(mock_ec2_client):
@@ -817,6 +858,61 @@ def test_snapshot_instance(mock_ec2_client):
 
     result = snapshot_instance(instance_id)
     assert result is True
+
+
+def test_asg_detach_instance_missing_instance_id_returns_false():
+    """A falsy instance_id must be rejected before making any AWS calls."""
+    assert asg_detach_instance(None) is False
+    assert asg_detach_instance("") is False
+
+
+def test_asg_detach_instance_no_asg_membership_returns_false(aws_credentials):
+    """An instance not in any ASG is a no-op and must not be reported as a successful action."""
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        ec2 = boto3.client("ec2", region_name="us-east-1")
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        subnet = ec2.create_subnet(VpcId=vpc["Vpc"]["VpcId"], CidrBlock="10.0.1.0/24")
+        instance = ec2.run_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            SubnetId=subnet["Subnet"]["SubnetId"],
+        )
+        instance_id = instance["Instances"][0]["InstanceId"]
+
+        assert asg_detach_instance(instance_id) is False
+
+
+def test_asg_detach_instance_detaches_when_in_asg(aws_credentials):
+    """When the instance IS in an ASG, detaching returns True and actually removes it from the ASG."""
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        ec2 = boto3.client("ec2", region_name="us-east-1")
+        autoscaling = boto3.client("autoscaling", region_name="us-east-1")
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        subnet = ec2.create_subnet(VpcId=vpc["Vpc"]["VpcId"], CidrBlock="10.0.1.0/24")
+
+        autoscaling.create_launch_configuration(LaunchConfigurationName="lc1", ImageId="ami-12345678", InstanceType="t2.micro")
+        autoscaling.create_auto_scaling_group(
+            AutoScalingGroupName="asg1",
+            LaunchConfigurationName="lc1",
+            MinSize=0,
+            MaxSize=2,
+            DesiredCapacity=1,
+            VPCZoneIdentifier=subnet["Subnet"]["SubnetId"],
+        )
+        group = autoscaling.describe_auto_scaling_groups(AutoScalingGroupNames=["asg1"])["AutoScalingGroups"][0]
+        instance_id = group["Instances"][0]["InstanceId"]
+
+        assert asg_detach_instance(instance_id) is True
+
+        remaining = autoscaling.describe_auto_scaling_instances(InstanceIds=[instance_id])["AutoScalingInstances"]
+        assert remaining == []
 
 
 # --- lambda_handler action dispatch tests ---

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -63,6 +63,18 @@ def test_config_unknown_finding_type():
         assert config.get_reliability() == 5
 
 
+def test_real_config_actions_are_all_lists():
+    """Every playbook entry in the real config.json must use list-form actions.
+
+    Regression test for config.json's Persistence:IAMUser/NetworkPermissions entry,
+    which held actions as a bare string ("disable_sg_access") instead of a list.
+    """
+    real_config_path = Path(__file__).parent.parent / "GDPatrol" / "config.json"
+    data = json.loads(real_config_path.read_text())
+    for playbook in data["playbooks"]["playbook"]:
+        assert isinstance(playbook["actions"], list), f"{playbook['type']} actions is not a list"
+
+
 @patch("GDPatrol.lambda_function.bedrock_client")
 def test_enhance_message_with_claude(mock_bedrock):
     """Test that enhance_message_with_claude calls Bedrock and appends AI Analysis."""

--- a/tests/test_nacl_import.py
+++ b/tests/test_nacl_import.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from nacl_import import TABLE_NAME, seed_tracking_table
+
+
+def create_gdpatrol_table(dynamodb_client):
+    dynamodb_client.create_table(
+        TableName=TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "network_acl_id", "KeyType": "HASH"},
+            {"AttributeName": "created_at", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "network_acl_id", "AttributeType": "S"},
+            {"AttributeName": "created_at", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def test_seed_tracking_table_excludes_default_deny(mock_ec2_client, mock_dynamodb_client):
+    """Only ingress deny rules with a /32 CidrBlock (GDPatrol-managed) get seeded;
+    the implicit undeletable default-deny at rule 32767 must be excluded."""
+    create_gdpatrol_table(mock_dynamodb_client)
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    nacl_id = mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])["NetworkAcl"]["NetworkAclId"]
+
+    mock_ec2_client.create_network_acl_entry(
+        NetworkAclId=nacl_id, RuleNumber=32767, Protocol="-1", RuleAction="deny", Egress=False, CidrBlock="0.0.0.0/0"
+    )
+    mock_ec2_client.create_network_acl_entry(
+        NetworkAclId=nacl_id, RuleNumber=100, Protocol="-1", RuleAction="deny", Egress=False, CidrBlock="198.51.100.5/32"
+    )
+
+    seed_tracking_table()
+
+    items = mock_dynamodb_client.scan(TableName=TABLE_NAME)["Items"]
+    assert len(items) == 1
+    assert items[0]["network_acl_id"]["S"] == nacl_id
+    assert items[0]["rule_number"]["S"] == "100"
+
+
+def test_seed_tracking_table_is_idempotent(mock_ec2_client, mock_dynamodb_client):
+    """Re-running the seeder must not duplicate a tracking row for the same rule."""
+    create_gdpatrol_table(mock_dynamodb_client)
+    vpc = mock_ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+    nacl_id = mock_ec2_client.create_network_acl(VpcId=vpc["Vpc"]["VpcId"])["NetworkAcl"]["NetworkAclId"]
+    mock_ec2_client.create_network_acl_entry(
+        NetworkAclId=nacl_id, RuleNumber=100, Protocol="-1", RuleAction="deny", Egress=False, CidrBlock="198.51.100.5/32"
+    )
+
+    seed_tracking_table()
+    seed_tracking_table()
+
+    items = mock_dynamodb_client.scan(TableName=TABLE_NAME)["Items"]
+    assert len(items) == 1


### PR DESCRIPTION
## Summary

Fixes ~20 findings from a full-repo review of GDPatrol — a tool that auto-remediates GuardDuty findings on a live AWS account, so these are the bugs that would cause outages, silent failures to contain a threat, or a privilege-escalation surface. Built TDD with task-scoped reviews and a whole-branch cross-cutting review; the suite went **32 → 71 tests**, ruff clean.

Independent of the [coverage PR](https://github.com/babyhuey/GDPatrol/pull/15) and the alert-levels PR (which follows) — this one is pure correctness/safety.

### Remediation engine (`GDPatrol/lambda_function.py`)
- **NACL lock was keyed per-IP but the operation mutates every NACL** — concurrent findings for different IPs raced and silently failed to block. Now a single shared lock serializes all NACL mutations (including `whitelist_ip`, which took no lock at all), with a larger retry budget so bursts queue instead of failing.
- **"Delete oldest rule" deleted the *newest* blocked IP** (lowest rule number = newest under the decrement scheme). Fixed to select the correct rule among GDPatrol's own `/32` rules.
- **New rule-number allocator** that never collides with a customer's ALLOW rule and searches the high range instead of hard-evicting a fixed slot; returns "full" so the caller cleans up. Thoroughly unit-tested (empty/collision/exhaustion/full).
- **Aggressive cleanup could delete a customer's own NACL rules** — it counted and evicted *all* deny rules, not just GDPatrol's `/32` host blocks. Now scoped to GDPatrol-managed rules and ordered by DynamoDB `created_at` (not rule number, which no longer tracks age).
- **`quarantine_instance` only isolated the primary ENI** — multi-ENI instances kept a live path. Now applies the quarantine SG to every ENI.
- **`whitelist_ip` / `asg_detach_instance` reported success for no-ops** — now validate inputs and return honestly, so the Slack summary can't count a no-op as a containment.
- **The notify block could crash *after* remediation ran** (direct indexing + a raw-severity comparison that throws on a string severity), dropping the alert. Hardened with `.get()` and reuse of the parsed float severity; `Config`/parse errors are caught.
- **DNS blacklisting** now sets a socket timeout (a hostile nameserver can't hang the invocation) and blocks all resolved A records.

### Infra
- **`nacl_import.py` poisoned the tracking table** by seeding non-GDPatrol rules (the implicit default-deny, customer subnet denies), which wedged blocking once a NACL filled up. Now seeds only `/32` ingress denies, idempotently.
- **`deploy.py` protection gaps:** re-enable a disabled detector on redeploy; get-or-create the IAM role instead of delete+recreate (no assume-role gap); EventBridge upsert instead of delete-before-put (no finding-drop window); handle `ResourceConflictException` on `create_function` with a `function_updated` waiter before reconfigure; stable EventBridge target Id and `add_permission` StatementId so redeploys don't accumulate toward the hard 5-targets/rule and policy-size limits.
- **`lambda_policy.json`:** added an `iam:PolicyName` condition to `PutUserPolicy`/`DeleteUserPolicy` (closes a privilege-escalation primitive), scoped `dynamodb:*` to the 4 verbs used, and — caught by the cross-cutting review — swapped the dead `ec2:ModifyInstanceAttribute` for the `ec2:ModifyNetworkInterfaceAttribute` the multi-ENI quarantine now calls (without it, quarantine would `AccessDenied` in production). A new static test asserts the policy grants every EC2 action the code calls — moto can't catch this since it doesn't enforce IAM.
- **`config.json`:** the one bare-string `actions` entry is now a list; a test asserts all entries use list form.

## Test plan
- [x] `pytest` — 71 passed (32 baseline + 39 new), ruff clean. New tests are moto-backed or precise mock-arg assertions, RED-verified against pre-fix code where feasible.
- [x] Scope confirmed: no alert-level threshold (`> 10` / `> 5`) or `reliability` changes leaked in (those are a separate PR); only the 8 intended files changed.
- [ ] `deploy.py` has no unit harness — its changes were verified against boto3 API contracts by review, not tests. Recommend a sandbox redeploy before relying on them.

https://claude.ai/code/session_0158xfJyVN5H28Pbrj2JWGag