### PR TITLE
Fix IndexError on findings for terminated instances (empty networkInterfaces)

### DIFF
--- a/GDPatrol/lambda_function.py
+++ b/GDPatrol/lambda_function.py
@@ -850,7 +850,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
     if resource_type == "Instance":
         instance = event["resource"]["instanceDetails"]
         instance_id = instance["instanceId"]
-        vpc_id = instance["networkInterfaces"][0]["vpcId"]
+        # A terminated instance has no ENIs; leave vpc_id None (skips quarantine) rather than crash.
+        network_interfaces = instance.get("networkInterfaces") or []
+        vpc_id = network_interfaces[0]["vpcId"] if network_interfaces else None
     elif resource_type == "AccessKey":
         username = event["resource"]["accessKeyDetails"]["userName"]
 

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -1897,6 +1897,52 @@ def test_lambda_handler_kubernetes_finding(monkeypatch):
         mock_blacklist.assert_called_once_with("198.51.100.42")
 
 
+def test_lambda_handler_terminated_instance_without_enis(monkeypatch):
+    """A finding on a terminated instance (networkInterfaces: []) must not crash the handler —
+    the IP action must still run and the alert must still publish (no VPC just means no quarantine)."""
+    monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")
+
+    event = {
+        "id": "test-terminated",
+        "type": "Recon:EC2/PortProbeUnprotectedPort",
+        "severity": 8,
+        "accountId": "123456789012",
+        "region": "us-east-1",
+        "resource": {
+            "resourceType": "Instance",
+            "instanceDetails": {
+                "instanceId": "i-00ae66540c5ef9603",
+                "instanceState": "terminated",
+                "networkInterfaces": [],
+            },
+        },
+        "service": {
+            "action": {
+                "actionType": "PORT_PROBE",
+                "portProbeAction": {
+                    "portProbeDetails": [{"remoteIpDetails": {"ipAddressV4": "185.180.141.38"}}],
+                },
+            },
+            "count": 1,
+            "eventFirstSeen": "x",
+            "eventLastSeen": "y",
+        },
+        "description": "Port probe on a terminated instance",
+    }
+    config_data = {
+        "playbooks": {"playbook": [{"type": "Recon:EC2/PortProbeUnprotectedPort", "actions": ["blacklist_ip"], "reliability": 5}]}
+    }
+    with (
+        patch("builtins.open", MagicMock()) as mock_open,
+        patch("GDPatrol.lambda_function.publish_message") as mock_publish,
+        patch("GDPatrol.lambda_function.blacklist_ip", return_value=True) as mock_blacklist,
+    ):
+        mock_open.return_value.__enter__.return_value.read.return_value = json.dumps(config_data)
+        lambda_handler(event, None)  # must not raise IndexError
+        mock_blacklist.assert_called_once_with("185.180.141.38")
+    mock_publish.assert_called_once()
+
+
 def test_lambda_handler_fractional_severity_crosses_gate(monkeypatch):
     """A fractional severity like 5.5 must not be truncated to 5, which would under-count the reliability gate."""
     monkeypatch.setenv("SLACK_WEB_HOOK_URL", "https://hooks.slack.com/services/test")


### PR DESCRIPTION
Caught live in the test account (finding 0ecf9f45..., 2026-07-07 21:51 UTC): GuardDuty re-fired a port-probe finding for a terminated autoscaled GitLab runner. `instanceDetails.networkInterfaces` is `[]` for terminated instances, so `instance["networkInterfaces"][0]["vpcId"]` raised IndexError and killed the invocation — no actions, no Slack alert.

Fix: leave `vpc_id` as None when there are no ENIs (quarantine is meaningless for a terminated instance); IP-based actions and alerting proceed normally. Regression test included, modeled on the live event. 107 tests pass, ruff clean.